### PR TITLE
Fix Sphinx build when notebooks are present

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,5 @@ nbsphinx
 sphinx-rtd-theme>=1.2
 myst-parser>=0.18
 furo
+ipykernel
+pypandoc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,9 @@
 import os
 import sys
+import pypandoc
+
+# Ensure pandoc is available for nbsphinx
+pypandoc.download_pandoc()
 # 1. Tell Sphinx where to find your code:
 sys.path.insert(0, os.path.abspath('../../src'))
 
@@ -24,6 +28,11 @@ autodoc_default_options = {
     'undoc-members':True, #also include members without docstrings
     'show-inheritance':True #for classes, show base classes
 }
+
+# Execute notebooks so GitHub Pages gets static output.
+nbsphinx_execute = 'always'
+# Fail the build if cells error out.
+nbsphinx_allow_errors = False
 
 # -- Options for HTML output -------------------------------------------------
 html_theme = 'furo'  # or 'sphinx_rtd_theme', etc.

--- a/docs/source/notebooks/tree_species_intro.ipynb
+++ b/docs/source/notebooks/tree_species_intro.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TreeSpecies.Sweden.pinus_sylvestris"
+    "TreeSpecies.Sweden.pinus_sylvestris\n"
    ]
   },
   {
@@ -51,8 +51,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "TreeSpecies.Sweden.pinus.full_name",
-    "list(TreeSpecies.Sweden.pinus)"
+    "TreeSpecies.Sweden.pinus.full_name\n",
+    "list(TreeSpecies.Sweden.pinus)\n"
    ]
   },
   {
@@ -68,8 +68,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "parse_tree_species('Pinus sylvestris')",
-    "parse_tree_species('pInus sylvestris') == TreeSpecies.Sweden.pinus_sylvestris"
+    "parse_tree_species('Pinus sylvestris')\n",
+    "parse_tree_species('pInus sylvestris') == TreeSpecies.Sweden.pinus_sylvestris\n"
    ]
   },
   {
@@ -85,8 +85,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "isinstance(TreeSpecies.Sweden.pinus_sylvestris, TreeName)",
-    "type(TreeSpecies.Sweden)"
+    "isinstance(TreeSpecies.Sweden.pinus_sylvestris, TreeName)\n",
+    "type(TreeSpecies.Sweden)\n"
    ]
   },
   {
@@ -102,8 +102,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "ALNUS_GLUTINOSA in TreeSpecies.Sweden.alnus",
-    "ALNUS_INCANA in TreeSpecies.Sweden.alnus"
+    "ALNUS_GLUTINOSA in TreeSpecies.Sweden.alnus\n",
+    "ALNUS_INCANA in TreeSpecies.Sweden.alnus\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- install `ipykernel` and `pypandoc` in documentation requirements
- ensure pandoc is available and execute notebooks during the docs build
- fix newline issues so `tree_species_intro.ipynb` runs without errors

## Testing
- `pytest -q`
- `make html`


------
https://chatgpt.com/codex/tasks/task_e_6878a6d14b78832982df9e790546e1ba