### PR TITLE
Fix Sphinx build when notebooks are present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 build/
 pyforestry.egg-info
 venv/
+.coverage
+pandoc-*.deb
+docs/source/pandoc-*.deb

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,5 @@ nbsphinx
 sphinx-rtd-theme>=1.2
 myst-parser>=0.18
 furo
+ipykernel
+pypandoc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,7 +1,22 @@
 import os
 import sys
-# 1. Tell Sphinx where to find your code:
-sys.path.insert(0, os.path.abspath('../../src'))
+import pypandoc
+
+# Ensure pandoc is available for nbsphinx and put it on PATH
+pypandoc.download_pandoc()
+pandoc_path = pypandoc.get_pandoc_path()
+os.environ['PATH'] = os.pathsep.join([
+    os.path.dirname(pandoc_path),
+    os.environ.get('PATH', ''),
+])
+
+# 1. Tell Sphinx where to find your code and expose it to executed notebooks
+src_dir = os.path.abspath('../../src')
+sys.path.insert(0, src_dir)
+os.environ['PYTHONPATH'] = os.pathsep.join([
+    src_dir,
+    os.environ.get('PYTHONPATH', ''),
+])
 
 # -- Project information -----------------------------------------------------
 project = 'pyforestry'
@@ -24,6 +39,11 @@ autodoc_default_options = {
     'undoc-members':True, #also include members without docstrings
     'show-inheritance':True #for classes, show base classes
 }
+
+# Execute notebooks so GitHub Pages gets static output.
+nbsphinx_execute = 'always'
+# Fail the build if cells error out.
+nbsphinx_allow_errors = False
 
 # -- Options for HTML output -------------------------------------------------
 html_theme = 'furo'  # or 'sphinx_rtd_theme', etc.

--- a/docs/source/notebooks/tree_species_intro.ipynb
+++ b/docs/source/notebooks/tree_species_intro.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TreeSpecies.Sweden.pinus_sylvestris"
+    "TreeSpecies.Sweden.pinus_sylvestris\n"
    ]
   },
   {
@@ -51,8 +51,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "TreeSpecies.Sweden.pinus.full_name",
-    "list(TreeSpecies.Sweden.pinus)"
+    "TreeSpecies.Sweden.pinus.full_name\n",
+    "list(TreeSpecies.Sweden.pinus)\n"
    ]
   },
   {
@@ -68,8 +68,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "parse_tree_species('Pinus sylvestris')",
-    "parse_tree_species('pInus sylvestris') == TreeSpecies.Sweden.pinus_sylvestris"
+    "parse_tree_species('Pinus sylvestris')\n",
+    "parse_tree_species('pInus sylvestris') == TreeSpecies.Sweden.pinus_sylvestris\n"
    ]
   },
   {
@@ -85,8 +85,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "isinstance(TreeSpecies.Sweden.pinus_sylvestris, TreeName)",
-    "type(TreeSpecies.Sweden)"
+    "isinstance(TreeSpecies.Sweden.pinus_sylvestris, TreeName)\n",
+    "type(TreeSpecies.Sweden)\n"
    ]
   },
   {
@@ -102,8 +102,8 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "ALNUS_GLUTINOSA in TreeSpecies.Sweden.alnus",
-    "ALNUS_INCANA in TreeSpecies.Sweden.alnus"
+    "ALNUS_GLUTINOSA in TreeSpecies.Sweden.alnus\n",
+    "ALNUS_INCANA in TreeSpecies.Sweden.alnus\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- install `ipykernel` and `pypandoc` in documentation requirements
- ensure pandoc is on the `PATH` and expose the source directory to notebooks
- ignore generated coverage and pandoc downloads

## Testing
- `pytest -q`
- `make -C docs html`


------
https://chatgpt.com/codex/tasks/task_e_6878a6d14b78832982df9e790546e1ba