### PR TITLE
Return SiteIndexValue for Ekö birch model

### DIFF
--- a/src/pyforestry/sweden/siteindex/sis/eko_2008.py
+++ b/src/pyforestry/sweden/siteindex/sis/eko_2008.py
@@ -1,9 +1,12 @@
+from pyforestry.base.helpers import Age, SiteIndexValue, TreeSpecies
+
 from ...site.enums import (
     SwedenBottomLayer,
     SwedenFieldLayer,
     SwedenSoilMoisture,
     SwedenSoilWater,
 )
+from ..eriksson_1997 import eriksson_1997_height_trajectory_sweden_birch
 
 
 def eko_pm_2008_estimate_si_birch(
@@ -13,7 +16,7 @@ def eko_pm_2008_estimate_si_birch(
     ground_layer: SwedenBottomLayer,
     lateral_water: SwedenSoilWater,
     soil_moisture: SwedenSoilMoisture,
-) -> float:
+) -> SiteIndexValue:
     """
     Estimate SIH50 (Site Index for Birch H50) with stand factors based on Ekö et al. (2008).
 
@@ -30,7 +33,7 @@ def eko_pm_2008_estimate_si_birch(
         soil_moisture (SwedenSoilMoisture): Soil moisture class.
 
     Returns:
-        float: Site Index (H50) for Birch.
+        SiteIndexValue: Site index (H50) for Birch.
 
     Raises:
         ValueError: If the soil moisture type is not "mesic" (2) or "moist" (4).
@@ -60,9 +63,11 @@ def eko_pm_2008_estimate_si_birch(
     lateral_frequent = 1 if lw_code == 4 else 0
     northern = 1 if latitude > 60 else 0
 
+    si_value: float
+
     # Conditions for Northern Sweden, Mesic
     if northern == 1 and mesic == 1:
-        return (
+        si_value = (
             88.469
             - (0.00869 * altitude)
             - (1.112 * latitude)
@@ -72,7 +77,7 @@ def eko_pm_2008_estimate_si_birch(
 
     # Conditions for Northern Sweden, Moist
     elif northern == 1 and moist == 1:
-        return (
+        si_value = (
             77.862
             - (0.0103 * altitude)
             - (0.976 * latitude)
@@ -84,7 +89,7 @@ def eko_pm_2008_estimate_si_birch(
 
     # Conditions for Southern Sweden, Mesic
     elif northern == 0 and mesic == 1:
-        return (
+        si_value = (
             -9.910
             + (0.467 * latitude)
             + (2.956 * grasses)
@@ -95,7 +100,7 @@ def eko_pm_2008_estimate_si_birch(
 
     # Conditions for Southern Sweden, Moist
     elif northern == 0 and moist == 1:
-        return (
+        si_value = (
             0.259
             - (0.00729 * altitude)
             + (0.287 * latitude)
@@ -112,3 +117,10 @@ def eko_pm_2008_estimate_si_birch(
         raise ValueError(
             "Can only choose between SwedenSoilMoisture.MOIST or " "SwedenSoilMoisture.MESIC."
         )
+
+    return SiteIndexValue(
+        si_value,
+        reference_age=Age.DBH(50),
+        species={TreeSpecies.Sweden.betula_pendula, TreeSpecies.Sweden.betula_pubescens},
+        fn=eriksson_1997_height_trajectory_sweden_birch,
+    )

--- a/tests/sweden/test_eko_2008_sis.py
+++ b/tests/sweden/test_eko_2008_sis.py
@@ -1,0 +1,18 @@
+from pyforestry.base.helpers import Age, SiteIndexValue
+from pyforestry.sweden.site.enums import Sweden
+from pyforestry.sweden.siteindex.sis.eko_2008 import eko_pm_2008_estimate_si_birch
+
+
+def test_eko_pm_2008_returns_siteindexvalue():
+    si = eko_pm_2008_estimate_si_birch(
+        altitude=100.0,
+        latitude=60.0,
+        vegetation=Sweden.FieldLayer.BILBERRY,
+        ground_layer=Sweden.BottomLayer.FRESH_MOSS,
+        lateral_water=Sweden.SoilWater.SELDOM_NEVER,
+        soil_moisture=Sweden.SoilMoistureEnum.MESIC,
+    )
+    assert isinstance(si, SiteIndexValue)
+    assert si.reference_age == Age.DBH(50)
+    assert 0 < float(si) < 50
+


### PR DESCRIPTION
## Summary
- update Ekö 2008 birch site index estimation to return `SiteIndexValue`
- expose reference age 50 using Eriksson 1997 birch trajectory
- add test for the Ekö birch site index wrapper

## Testing
- `ruff check src/pyforestry/sweden/siteindex/sis/eko_2008.py tests/sweden/test_eko_2008_sis.py`
- `pytest -q tests/sweden/test_eko_2008_sis.py`

------
https://chatgpt.com/codex/tasks/task_e_68790f6afee08329ad30df2ffe3eff4c