### PR TITLE
Fix tree genus spelling

### DIFF
--- a/src/pyforestry/base/helpers/tree_species.py
+++ b/src/pyforestry/base/helpers/tree_species.py
@@ -69,7 +69,7 @@ def get_tree_type_by_genus(genus: str) -> str:
         "pseudotsuga",
         "tsuga",
         "pinus",
-        "seqouia",
+        "sequoia",
         "sequoiadendron",
         "chamaecyparis",
         "cupressaceae",


### PR DESCRIPTION
## Summary
- fix spelling of `sequoia` genus in tree species helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792b109ed88329a8eacfcb26c26534