### PR TITLE
Add timber bucking demo notebook

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,5 +9,6 @@ pyforestry Documentation
    
    api/modules
    notebooks/tree_species_intro
+   notebooks/timber_bucking_demo
 
 ..

--- a/docs/source/notebooks/timber_bucking_demo.ipynb
+++ b/docs/source/notebooks/timber_bucking_demo.ipynb
@@ -1,0 +1,132 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Timber bucking demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates timber objects, tapers, pricelists, the Nasberg bucking algorithm and how solution cubes store many results in `xarray`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from pyforestry.sweden.timber.swe_timber import SweTimber\n",
+    "from pyforestry.sweden.taper import EdgrenNylinder1949\n",
+    "from pyforestry.base.pricelist import create_pricelist_from_data\n",
+    "from pyforestry.base.pricelist.data.mellanskog_2013 import Mellanskog_2013_price_data\n",
+    "from pyforestry.base.timber_bucking.nasberg_1985 import Nasberg_1985_BranchBound, BuckingConfig\n",
+    "from pyforestry.base.pricelist.solutioncube import SolutionCube"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create timber object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "timber = SweTimber(species='pinus sylvestris', diameter_cm=18, height_m=25)\n",
+    "timber"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load pricelist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "pricelist = create_pricelist_from_data(Mellanskog_2013_price_data, species_to_load='pinus sylvestris')\n",
+    "pricelist.Timber.keys()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run bucking optimizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "optimizer = Nasberg_1985_BranchBound(timber, pricelist, EdgrenNylinder1949)\n",
+    "result = optimizer.calculate_tree_value(min_diam_dead_wood=99, config=BuckingConfig(save_sections=True))\n",
+    "result"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "result.plot()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate a small solution cube"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "cube = SolutionCube.generate(\n    pricelist_data=Mellanskog_2013_price_data,\n    taper_model=EdgrenNylinder1949,\n    species_list=['picea abies'],\n    dbh_range=(20,22),\n    height_range=(15,15.2),\n    dbh_step=2,\n    height_step=0.2,\n    workers=1\n)\n",
+    "cube.dataset"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "cube.lookup(species='picea abies', dbh=20.0, height=15.0)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add new notebook demonstrating timber bucking, tapers, pricelists and solution cubes
- reference new notebook in docs index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792d630d0483298bfb995925a831bd