### PR TITLE
Fix circular import during docs build

### DIFF
--- a/src/pyforestry/sweden/biomass/marklund_1988.py
+++ b/src/pyforestry/sweden/biomass/marklund_1988.py
@@ -1,294 +1,590 @@
-import numpy as np
+import inspect
 from typing import Optional
+
+import numpy as np
+
 from pyforestry.base.timber import Timber
+
 
 def Marklund_1988_T1(diameter_cm):
     return np.exp(-2.3388 + 11.3264 * (diameter_cm / (diameter_cm + 13)))
 
+
 def Marklund_1988_T2(diameter_cm, height_m):
-    return np.exp(-2.6768 + 7.5939 * (diameter_cm / (diameter_cm + 13)) + 0.0151 * height_m + 0.8799 * np.log(height_m))
+    return np.exp(
+        -2.6768
+        + 7.5939 * (diameter_cm / (diameter_cm + 13))
+        + 0.0151 * height_m
+        + 0.8799 * np.log(height_m)
+    )
+
 
 def Marklund_1988_T3(diameter_cm, height_m, double_bark_mm, age):
-    return np.exp(-2.6232 + 7.7318 * (diameter_cm / (diameter_cm + 13)) + 0.0139 * height_m + 0.8625 * np.log(height_m) - 0.0704 * np.log(double_bark_mm) + 0.00185 * age)
+    return np.exp(
+        -2.6232
+        + 7.7318 * (diameter_cm / (diameter_cm + 13))
+        + 0.0139 * height_m
+        + 0.8625 * np.log(height_m)
+        - 0.0704 * np.log(double_bark_mm)
+        + 0.00185 * age
+    )
 
-def Marklund_1988_T4(diameter_cm, height_m, double_bark_mm, age, form_quotient5=None, form_quotient3=None, altitude_m=None):
+
+def Marklund_1988_T4(
+    diameter_cm,
+    height_m,
+    double_bark_mm,
+    age,
+    form_quotient5=None,
+    form_quotient3=None,
+    altitude_m=None,
+):
     if form_quotient5 is not None and form_quotient3 is not None:
-        print('Either form_quotient5 or form_quotient3 can be supplied. Not both.')
-        print('form_quotient5 taking precedence.')
+        print("Either form_quotient5 or form_quotient3 can be supplied. Not both.")
+        print("form_quotient5 taking precedence.")
         form_quotient3 = None
-    return np.exp(-2.4826 + 7.9039 * (diameter_cm / (diameter_cm + 13)) + 0.0184 * height_m + 0.6939 * np.log(height_m) - 0.0731 * np.log(double_bark_mm) + 0.00182 * age + 0.2382 * (form_quotient5 or 0) + 0.2217 * (form_quotient3 or 0) - 0.1596 * (altitude_m or 0))
+    return np.exp(
+        -2.4826
+        + 7.9039 * (diameter_cm / (diameter_cm + 13))
+        + 0.0184 * height_m
+        + 0.6939 * np.log(height_m)
+        - 0.0731 * np.log(double_bark_mm)
+        + 0.00182 * age
+        + 0.2382 * (form_quotient5 or 0)
+        + 0.2217 * (form_quotient3 or 0)
+        - 0.1596 * (altitude_m or 0)
+    )
+
 
 MarklundPineStem = [Marklund_1988_T1, Marklund_1988_T2, Marklund_1988_T3, Marklund_1988_T4]
 MarklundPineStem = sorted(MarklundPineStem, key=lambda f: f.__code__.co_argcount, reverse=True)
+
 
 # Stem wood functions
 def Marklund_1988_T5(diameter_cm):
     return np.exp(-2.2184 + 11.4219 * (diameter_cm / (diameter_cm + 14)))
 
+
 def Marklund_1988_T6(diameter_cm, height_m):
-    return np.exp(-2.6864 + 7.6066 * (diameter_cm / (diameter_cm + 14)) + 0.0200 * height_m + 0.8658 * np.log(height_m))
+    return np.exp(
+        -2.6864
+        + 7.6066 * (diameter_cm / (diameter_cm + 14))
+        + 0.0200 * height_m
+        + 0.8658 * np.log(height_m)
+    )
+
 
 def Marklund_1988_T7(diameter_cm, height_m, double_bark_mm, age):
-    return np.exp(-2.5325 + 7.8936 * (diameter_cm / (diameter_cm + 14)) + 0.0231 * height_m + 0.7887 * np.log(height_m) - 0.1065 * np.log(double_bark_mm) + 0.00201 * age)
+    return np.exp(
+        -2.5325
+        + 7.8936 * (diameter_cm / (diameter_cm + 14))
+        + 0.0231 * height_m
+        + 0.7887 * np.log(height_m)
+        - 0.1065 * np.log(double_bark_mm)
+        + 0.00201 * age
+    )
 
-def Marklund_1988_T8(diameter_cm, height_m, double_bark_mm, age, form_quotient5=None, form_quotient3=None, altitude_m=None):
+
+def Marklund_1988_T8(
+    diameter_cm,
+    height_m,
+    double_bark_mm,
+    age,
+    form_quotient5=None,
+    form_quotient3=None,
+    altitude_m=None,
+):
     if form_quotient5 is not None and form_quotient3 is not None:
-        print('Either form_quotient5 or form_quotient3 can be supplied. Not both.')
-        print('form_quotient5 taking precedence.')
+        print("Either form_quotient5 or form_quotient3 can be supplied. Not both.")
+        print("form_quotient5 taking precedence.")
         form_quotient3 = None
-    return np.exp(-2.0028 + 7.9455 * (diameter_cm / (diameter_cm + 14)) + 0.0439 * height_m + 0.2437 * np.log(height_m) - 0.0875 * np.log(double_bark_mm) + 0.00172 * age + 0.7778 * (form_quotient5 or 0) + 0.4855 * (form_quotient3 or 0) - 0.1557 * (altitude_m or 0))
+    return np.exp(
+        -2.0028
+        + 7.9455 * (diameter_cm / (diameter_cm + 14))
+        + 0.0439 * height_m
+        + 0.2437 * np.log(height_m)
+        - 0.0875 * np.log(double_bark_mm)
+        + 0.00172 * age
+        + 0.7778 * (form_quotient5 or 0)
+        + 0.4855 * (form_quotient3 or 0)
+        - 0.1557 * (altitude_m or 0)
+    )
+
 
 MarklundPineStemWood = [Marklund_1988_T5, Marklund_1988_T6, Marklund_1988_T7, Marklund_1988_T8]
-MarklundPineStemWood = sorted(MarklundPineStemWood, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundPineStemWood = sorted(
+    MarklundPineStemWood, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Stem bark functions
 def Marklund_1988_T9(diameter_cm):
     return np.exp(-2.9748 + 8.8489 * (diameter_cm / (diameter_cm + 16)))
 
+
 def Marklund_1988_T10(diameter_cm, height_m):
-    return np.exp(-3.2765 + 7.2482 * (diameter_cm / (diameter_cm + 16)) + 0.4487 * np.log(height_m))
+    return np.exp(
+        -3.2765 + 7.2482 * (diameter_cm / (diameter_cm + 16)) + 0.4487 * np.log(height_m)
+    )
+
 
 def Marklund_1988_T11(diameter_cm, height_m, relative_bark_thickness):
-    return np.exp(-3.6065 + 7.0834 * (diameter_cm / (diameter_cm + 16)) + 0.5086 * np.log(height_m) + 0.0255 * relative_bark_thickness)
+    return np.exp(
+        -3.6065
+        + 7.0834 * (diameter_cm / (diameter_cm + 16))
+        + 0.5086 * np.log(height_m)
+        + 0.0255 * relative_bark_thickness
+    )
+
 
 def Marklund_1988_T12(diameter_cm, height_m, crown_base_height_m, relative_bark_thickness):
-    return np.exp(-3.5076 + 7.5295 * (diameter_cm / (diameter_cm + 16)) + 0.5629 * np.log(height_m) - 0.2271 * np.log(height_m - crown_base_height_m) + 0.0222 * relative_bark_thickness)
+    return np.exp(
+        -3.5076
+        + 7.5295 * (diameter_cm / (diameter_cm + 16))
+        + 0.5629 * np.log(height_m)
+        - 0.2271 * np.log(height_m - crown_base_height_m)
+        + 0.0222 * relative_bark_thickness
+    )
+
 
 MarklundPineBark = [Marklund_1988_T9, Marklund_1988_T10, Marklund_1988_T11, Marklund_1988_T12]
 MarklundPineBark = sorted(MarklundPineBark, key=lambda f: f.__code__.co_argcount, reverse=True)
+
 
 # Living branches functions
 def Marklund_1988_T13(diameter_cm):
     return np.exp(-2.9580 + 7.7428 * (diameter_cm / (diameter_cm + 18)))
 
+
 def Marklund_1988_T14(diameter_cm, height_m):
-    return np.exp(-3.0331 + 6.7610 * (diameter_cm / (diameter_cm + 18)) + 0.6565 * np.log(height_m))
+    return np.exp(
+        -3.0331 + 6.7610 * (diameter_cm / (diameter_cm + 18)) + 0.6565 * np.log(height_m)
+    )
+
 
 def Marklund_1988_T15(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-3.1398 + 6.6698 * (diameter_cm / (diameter_cm + 18)) + 0.6797 * np.log(height_m) - 0.2763 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -3.1398
+        + 6.6698 * (diameter_cm / (diameter_cm + 18))
+        + 0.6797 * np.log(height_m)
+        - 0.2763 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundPineLivingBranches = [Marklund_1988_T13, Marklund_1988_T14, Marklund_1988_T15]
-MarklundPineLivingBranches = sorted(MarklundPineLivingBranches, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundPineLivingBranches = sorted(
+    MarklundPineLivingBranches, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Needles functions
 def Marklund_1988_T16(diameter_cm):
     return np.exp(-3.5285 + 6.5301 * (diameter_cm / (diameter_cm + 20)))
 
+
 def Marklund_1988_T17(diameter_cm, height_m):
-    return np.exp(-3.6531 + 5.9425 * (diameter_cm / (diameter_cm + 20)) + 0.8165 * np.log(height_m))
+    return np.exp(
+        -3.6531 + 5.9425 * (diameter_cm / (diameter_cm + 20)) + 0.8165 * np.log(height_m)
+    )
+
 
 def Marklund_1988_T18(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-3.7941 + 5.8956 * (diameter_cm / (diameter_cm + 20)) + 0.8482 * np.log(height_m) - 0.2436 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -3.7941
+        + 5.8956 * (diameter_cm / (diameter_cm + 20))
+        + 0.8482 * np.log(height_m)
+        - 0.2436 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundPineNeedles = [Marklund_1988_T16, Marklund_1988_T17, Marklund_1988_T18]
-MarklundPineNeedles = sorted(MarklundPineNeedles, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundPineNeedles = sorted(
+    MarklundPineNeedles, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Dead branches functions
 def Marklund_1988_T19(diameter_cm):
     return np.exp(-4.3352 + 5.8210 * (diameter_cm / (diameter_cm + 23)))
 
+
 def Marklund_1988_T20(diameter_cm, height_m):
-    return np.exp(-4.4668 + 5.3836 * (diameter_cm / (diameter_cm + 23)) + 0.9584 * np.log(height_m))
+    return np.exp(
+        -4.4668 + 5.3836 * (diameter_cm / (diameter_cm + 23)) + 0.9584 * np.log(height_m)
+    )
+
 
 def Marklund_1988_T21(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-4.5368 + 5.4689 * (diameter_cm / (diameter_cm + 23)) + 0.8945 * np.log(height_m) - 0.3322 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -4.5368
+        + 5.4689 * (diameter_cm / (diameter_cm + 23))
+        + 0.8945 * np.log(height_m)
+        - 0.3322 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundPineDeadBranches = [Marklund_1988_T19, Marklund_1988_T20, Marklund_1988_T21]
-MarklundPineDeadBranches = sorted(MarklundPineDeadBranches, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundPineDeadBranches = sorted(
+    MarklundPineDeadBranches, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Stump-root system functions
 def Marklund_1988_T22(diameter_cm):
     return np.exp(-2.2114 + 7.5246 * (diameter_cm / (diameter_cm + 19)))
 
+
 def Marklund_1988_T23(diameter_cm, height_m):
-    return np.exp(-2.3323 + 6.4935 * (diameter_cm / (diameter_cm + 19)) + 0.6055 * np.log(height_m))
+    return np.exp(
+        -2.3323 + 6.4935 * (diameter_cm / (diameter_cm + 19)) + 0.6055 * np.log(height_m)
+    )
+
 
 def Marklund_1988_T24(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-2.4008 + 6.5480 * (diameter_cm / (diameter_cm + 19)) + 0.6187 * np.log(height_m) - 0.2052 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -2.4008
+        + 6.5480 * (diameter_cm / (diameter_cm + 19))
+        + 0.6187 * np.log(height_m)
+        - 0.2052 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundPineStumpRootSystem = [Marklund_1988_T22, Marklund_1988_T23, Marklund_1988_T24]
-MarklundPineStumpRootSystem = sorted(MarklundPineStumpRootSystem, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundPineStumpRootSystem = sorted(
+    MarklundPineStumpRootSystem, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Stump functions
 def Marklund_1988_T25(diameter_cm):
     return np.exp(-3.1444 + 8.4027 * (diameter_cm / (diameter_cm + 15)))
 
+
 def Marklund_1988_T26(diameter_cm, height_m):
-    return np.exp(-3.2571 + 7.3144 * (diameter_cm / (diameter_cm + 15)) + 0.7078 * np.log(height_m))
+    return np.exp(
+        -3.2571 + 7.3144 * (diameter_cm / (diameter_cm + 15)) + 0.7078 * np.log(height_m)
+    )
+
 
 def Marklund_1988_T27(diameter_cm, height_m, relative_bark_thickness):
-    return np.exp(-3.3738 + 7.1416 * (diameter_cm / (diameter_cm + 15)) + 0.7956 * np.log(height_m) + 0.0119 * relative_bark_thickness)
+    return np.exp(
+        -3.3738
+        + 7.1416 * (diameter_cm / (diameter_cm + 15))
+        + 0.7956 * np.log(height_m)
+        + 0.0119 * relative_bark_thickness
+    )
+
 
 MarklundPineStump = [Marklund_1988_T25, Marklund_1988_T26, Marklund_1988_T27]
 MarklundPineStump = sorted(MarklundPineStump, key=lambda f: f.__code__.co_argcount, reverse=True)
+
 
 # Norway Spruce Stem functions
 def Marklund_1988_S1(diameter_cm):
     return np.exp(-2.3450 + 11.1111 * (diameter_cm / (diameter_cm + 12)))
 
+
 def Marklund_1988_S2(diameter_cm, height_m):
-    return np.exp(-2.7190 + 7.8497 * (diameter_cm / (diameter_cm + 12)) + 0.0095 * height_m + 0.8693 * np.log(height_m))
+    return np.exp(
+        -2.7190
+        + 7.8497 * (diameter_cm / (diameter_cm + 12))
+        + 0.0095 * height_m
+        + 0.8693 * np.log(height_m)
+    )
+
 
 def Marklund_1988_S3(diameter_cm, height_m, double_bark_mm, age):
-    return np.exp(-2.5490 + 7.7334 * (diameter_cm / (diameter_cm + 12)) + 0.0125 * height_m + 0.8854 * np.log(height_m) - 0.0588 * np.log(double_bark_mm) + 0.00191 * age)
+    return np.exp(
+        -2.5490
+        + 7.7334 * (diameter_cm / (diameter_cm + 12))
+        + 0.0125 * height_m
+        + 0.8854 * np.log(height_m)
+        - 0.0588 * np.log(double_bark_mm)
+        + 0.00191 * age
+    )
+
 
 MarklundSpruceStem = [Marklund_1988_S1, Marklund_1988_S2, Marklund_1988_S3]
 MarklundSpruceStem = sorted(MarklundSpruceStem, key=lambda f: f.__code__.co_argcount, reverse=True)
+
 
 # Norway Spruce Living branches functions
 def Marklund_1988_S4(diameter_cm):
     return np.exp(-2.8470 + 8.6120 * (diameter_cm / (diameter_cm + 12)))
 
+
 def Marklund_1988_S5(diameter_cm, height_m):
-    return np.exp(-2.9892 + 7.1881 * (diameter_cm / (diameter_cm + 12)) + 0.7534 * np.log(height_m))
+    return np.exp(
+        -2.9892 + 7.1881 * (diameter_cm / (diameter_cm + 12)) + 0.7534 * np.log(height_m)
+    )
+
 
 def Marklund_1988_S6(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-3.1020 + 7.0834 * (diameter_cm / (diameter_cm + 12)) + 0.7707 * np.log(height_m) - 0.2426 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -3.1020
+        + 7.0834 * (diameter_cm / (diameter_cm + 12))
+        + 0.7707 * np.log(height_m)
+        - 0.2426 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundSpruceLivingBranches = [Marklund_1988_S4, Marklund_1988_S5, Marklund_1988_S6]
-MarklundSpruceLivingBranches = sorted(MarklundSpruceLivingBranches, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundSpruceLivingBranches = sorted(
+    MarklundSpruceLivingBranches, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Norway Spruce Dead branches functions
 def Marklund_1988_S7(diameter_cm):
     return np.exp(-4.3352 + 5.8210 * (diameter_cm / (diameter_cm + 23)))
 
+
 def Marklund_1988_S8(diameter_cm, height_m):
-    return np.exp(-4.4668 + 5.3836 * (diameter_cm / (diameter_cm + 23)) + 0.9584 * np.log(height_m))
+    return np.exp(
+        -4.4668 + 5.3836 * (diameter_cm / (diameter_cm + 23)) + 0.9584 * np.log(height_m)
+    )
+
 
 def Marklund_1988_S9(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-4.5368 + 5.4689 * (diameter_cm / (diameter_cm + 23)) + 0.8945 * np.log(height_m) - 0.3322 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -4.5368
+        + 5.4689 * (diameter_cm / (diameter_cm + 23))
+        + 0.8945 * np.log(height_m)
+        - 0.3322 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundSpruceDeadBranches = [Marklund_1988_S7, Marklund_1988_S8, Marklund_1988_S9]
-MarklundSpruceDeadBranches = sorted(MarklundSpruceDeadBranches, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundSpruceDeadBranches = sorted(
+    MarklundSpruceDeadBranches, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Norway Spruce Stump-root system functions
 def Marklund_1988_S10(diameter_cm):
     return np.exp(-2.2114 + 7.5246 * (diameter_cm / (diameter_cm + 19)))
 
+
 def Marklund_1988_S11(diameter_cm, height_m):
-    return np.exp(-2.3323 + 6.4935 * (diameter_cm / (diameter_cm + 19)) + 0.6055 * np.log(height_m))
+    return np.exp(
+        -2.3323 + 6.4935 * (diameter_cm / (diameter_cm + 19)) + 0.6055 * np.log(height_m)
+    )
+
 
 def Marklund_1988_S12(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-2.4008 + 6.5480 * (diameter_cm / (diameter_cm + 19)) + 0.6187 * np.log(height_m) - 0.2052 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -2.4008
+        + 6.5480 * (diameter_cm / (diameter_cm + 19))
+        + 0.6187 * np.log(height_m)
+        - 0.2052 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundSpruceStumpRootSystem = [Marklund_1988_S10, Marklund_1988_S11, Marklund_1988_S12]
-MarklundSpruceStumpRootSystem = sorted(MarklundSpruceStumpRootSystem, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundSpruceStumpRootSystem = sorted(
+    MarklundSpruceStumpRootSystem, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Norway Spruce Stump functions
 def Marklund_1988_S13(diameter_cm):
     return np.exp(-3.1444 + 8.4027 * (diameter_cm / (diameter_cm + 15)))
 
+
 def Marklund_1988_S14(diameter_cm, height_m):
-    return np.exp(-3.2571 + 7.3144 * (diameter_cm / (diameter_cm + 15)) + 0.7078 * np.log(height_m))
+    return np.exp(
+        -3.2571 + 7.3144 * (diameter_cm / (diameter_cm + 15)) + 0.7078 * np.log(height_m)
+    )
+
 
 def Marklund_1988_S15(diameter_cm, height_m, relative_bark_thickness):
-    return np.exp(-3.3738 + 7.1416 * (diameter_cm / (diameter_cm + 15)) + 0.7956 * np.log(height_m) + 0.0119 * relative_bark_thickness)
+    return np.exp(
+        -3.3738
+        + 7.1416 * (diameter_cm / (diameter_cm + 15))
+        + 0.7956 * np.log(height_m)
+        + 0.0119 * relative_bark_thickness
+    )
+
 
 MarklundSpruceStump = [Marklund_1988_S13, Marklund_1988_S14, Marklund_1988_S15]
-MarklundSpruceStump = sorted(MarklundSpruceStump, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundSpruceStump = sorted(
+    MarklundSpruceStump, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Birch Stem functions
 def Marklund_1988_B1(diameter_cm):
     return np.exp(-2.3450 + 11.1111 * (diameter_cm / (diameter_cm + 12)))
 
+
 def Marklund_1988_B2(diameter_cm, height_m):
-    return np.exp(-2.7190 + 7.8497 * (diameter_cm / (diameter_cm + 12)) + 0.0095 * height_m + 0.8693 * np.log(height_m))
+    return np.exp(
+        -2.7190
+        + 7.8497 * (diameter_cm / (diameter_cm + 12))
+        + 0.0095 * height_m
+        + 0.8693 * np.log(height_m)
+    )
+
 
 def Marklund_1988_B3(diameter_cm, height_m, double_bark_mm, age):
-    return np.exp(-2.5490 + 7.7334 * (diameter_cm / (diameter_cm + 12)) + 0.0125 * height_m + 0.8854 * np.log(height_m) - 0.0588 * np.log(double_bark_mm) + 0.00191 * age)
+    return np.exp(
+        -2.5490
+        + 7.7334 * (diameter_cm / (diameter_cm + 12))
+        + 0.0125 * height_m
+        + 0.8854 * np.log(height_m)
+        - 0.0588 * np.log(double_bark_mm)
+        + 0.00191 * age
+    )
+
 
 MarklundBirchStem = [Marklund_1988_B1, Marklund_1988_B2, Marklund_1988_B3]
 MarklundBirchStem = sorted(MarklundBirchStem, key=lambda f: f.__code__.co_argcount, reverse=True)
+
 
 # Birch Living branches functions
 def Marklund_1988_B4(diameter_cm):
     return np.exp(-2.8470 + 8.6120 * (diameter_cm / (diameter_cm + 12)))
 
+
 def Marklund_1988_B5(diameter_cm, height_m):
-    return np.exp(-2.9892 + 7.1881 * (diameter_cm / (diameter_cm + 12)) + 0.7534 * np.log(height_m))
+    return np.exp(
+        -2.9892 + 7.1881 * (diameter_cm / (diameter_cm + 12)) + 0.7534 * np.log(height_m)
+    )
+
 
 def Marklund_1988_B6(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-3.1020 + 7.0834 * (diameter_cm / (diameter_cm + 12)) + 0.7707 * np.log(height_m) - 0.2426 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -3.1020
+        + 7.0834 * (diameter_cm / (diameter_cm + 12))
+        + 0.7707 * np.log(height_m)
+        - 0.2426 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundBirchLivingBranches = [Marklund_1988_B4, Marklund_1988_B5, Marklund_1988_B6]
-MarklundBirchLivingBranches = sorted(MarklundBirchLivingBranches, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundBirchLivingBranches = sorted(
+    MarklundBirchLivingBranches, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Birch Dead branches functions
 def Marklund_1988_B7(diameter_cm):
     return np.exp(-4.3352 + 5.8210 * (diameter_cm / (diameter_cm + 23)))
 
+
 def Marklund_1988_B8(diameter_cm, height_m):
-    return np.exp(-4.4668 + 5.3836 * (diameter_cm / (diameter_cm + 23)) + 0.9584 * np.log(height_m))
+    return np.exp(
+        -4.4668 + 5.3836 * (diameter_cm / (diameter_cm + 23)) + 0.9584 * np.log(height_m)
+    )
+
 
 def Marklund_1988_B9(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-4.5368 + 5.4689 * (diameter_cm / (diameter_cm + 23)) + 0.8945 * np.log(height_m) - 0.3322 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -4.5368
+        + 5.4689 * (diameter_cm / (diameter_cm + 23))
+        + 0.8945 * np.log(height_m)
+        - 0.3322 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundBirchDeadBranches = [Marklund_1988_B7, Marklund_1988_B8, Marklund_1988_B9]
-MarklundBirchDeadBranches = sorted(MarklundBirchDeadBranches, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundBirchDeadBranches = sorted(
+    MarklundBirchDeadBranches, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Birch Stump-root system functions
 def Marklund_1988_B10(diameter_cm):
     return np.exp(-2.2114 + 7.5246 * (diameter_cm / (diameter_cm + 19)))
 
+
 def Marklund_1988_B11(diameter_cm, height_m):
-    return np.exp(-2.3323 + 6.4935 * (diameter_cm / (diameter_cm + 19)) + 0.6055 * np.log(height_m))
+    return np.exp(
+        -2.3323 + 6.4935 * (diameter_cm / (diameter_cm + 19)) + 0.6055 * np.log(height_m)
+    )
+
 
 def Marklund_1988_B12(diameter_cm, height_m, crown_base_height_m):
-    return np.exp(-2.4008 + 6.5480 * (diameter_cm / (diameter_cm + 19)) + 0.6187 * np.log(height_m) - 0.2052 * np.log(height_m - crown_base_height_m))
+    return np.exp(
+        -2.4008
+        + 6.5480 * (diameter_cm / (diameter_cm + 19))
+        + 0.6187 * np.log(height_m)
+        - 0.2052 * np.log(height_m - crown_base_height_m)
+    )
+
 
 MarklundBirchStumpRootSystem = [Marklund_1988_B10, Marklund_1988_B11, Marklund_1988_B12]
-MarklundBirchStumpRootSystem = sorted(MarklundBirchStumpRootSystem, key=lambda f: f.__code__.co_argcount, reverse=True)
+MarklundBirchStumpRootSystem = sorted(
+    MarklundBirchStumpRootSystem, key=lambda f: f.__code__.co_argcount, reverse=True
+)
+
 
 # Birch Stump functions
 def Marklund_1988_B13(diameter_cm):
     return np.exp(-3.1444 + 8.4027 * (diameter_cm / (diameter_cm + 15)))
 
+
 def Marklund_1988_B14(diameter_cm, height_m):
-    return np.exp(-3.2571 + 7.3144 * (diameter_cm / (diameter_cm + 15)) + 0.7078 * np.log(height_m))
+    return np.exp(
+        -3.2571 + 7.3144 * (diameter_cm / (diameter_cm + 15)) + 0.7078 * np.log(height_m)
+    )
+
 
 def Marklund_1988_B15(diameter_cm, height_m, relative_bark_thickness):
-    return np.exp(-3.3738 + 7.1416 * (diameter_cm / (diameter_cm + 15)) + 0.7956 * np.log(height_m) + 0.0119 * relative_bark_thickness)
+    return np.exp(
+        -3.3738
+        + 7.1416 * (diameter_cm / (diameter_cm + 15))
+        + 0.7956 * np.log(height_m)
+        + 0.0119 * relative_bark_thickness
+    )
+
 
 MarklundBirchStump = [Marklund_1988_B13, Marklund_1988_B14, Marklund_1988_B15]
 MarklundBirchStump = sorted(MarklundBirchStump, key=lambda f: f.__code__.co_argcount, reverse=True)
 
 species_map = {
-        'pinus sylvestris': {
-            'stem': MarklundPineStem,
-            'stem_wood': MarklundPineStemWood,
-            'stem_bark': MarklundPineBark,
-            'living_branches': MarklundPineLivingBranches,
-            'needles': MarklundPineNeedles,
-            'dead_branches': MarklundPineDeadBranches,
-            'stump_root_system': MarklundPineStumpRootSystem,
-            'stump': MarklundPineStump
-        },
-        'picea abies': {
-            'stem': MarklundSpruceStem,
-            'living_branches': MarklundSpruceLivingBranches,
-            'dead_branches': MarklundSpruceDeadBranches,
-            'stump_root_system': MarklundSpruceStumpRootSystem,
-            'stump': MarklundSpruceStump
-        },
-        'betula pendula': {
-            'stem': MarklundBirchStem,
-            'living_branches': MarklundBirchLivingBranches,
-            'dead_branches': MarklundBirchDeadBranches,
-            'stump_root_system': MarklundBirchStumpRootSystem,
-            'stump': MarklundBirchStump
-        },
-        'betula pubescens': {
-            'stem': MarklundBirchStem,
-            'living_branches': MarklundBirchLivingBranches,
-            'dead_branches': MarklundBirchDeadBranches,
-            'stump_root_system': MarklundBirchStumpRootSystem,
-            'stump': MarklundBirchStump
-        }
-    }
+    "pinus sylvestris": {
+        "stem": MarklundPineStem,
+        "stem_wood": MarklundPineStemWood,
+        "stem_bark": MarklundPineBark,
+        "living_branches": MarklundPineLivingBranches,
+        "needles": MarklundPineNeedles,
+        "dead_branches": MarklundPineDeadBranches,
+        "stump_root_system": MarklundPineStumpRootSystem,
+        "stump": MarklundPineStump,
+    },
+    "picea abies": {
+        "stem": MarklundSpruceStem,
+        "living_branches": MarklundSpruceLivingBranches,
+        "dead_branches": MarklundSpruceDeadBranches,
+        "stump_root_system": MarklundSpruceStumpRootSystem,
+        "stump": MarklundSpruceStump,
+    },
+    "betula pendula": {
+        "stem": MarklundBirchStem,
+        "living_branches": MarklundBirchLivingBranches,
+        "dead_branches": MarklundBirchDeadBranches,
+        "stump_root_system": MarklundBirchStumpRootSystem,
+        "stump": MarklundBirchStump,
+    },
+    "betula pubescens": {
+        "stem": MarklundBirchStem,
+        "living_branches": MarklundBirchLivingBranches,
+        "dead_branches": MarklundBirchDeadBranches,
+        "stump_root_system": MarklundBirchStumpRootSystem,
+        "stump": MarklundBirchStump,
+    },
+}
 
 
 # Wrapper function
-def Marklund_1988(species: Optional[str] = None, component: Optional[str] = None, *args, timber: Optional[Timber] = None, **kwargs):
+def Marklund_1988(
+    species: Optional[str] = None,
+    component: Optional[str] = None,
+    *args,
+    timber: Optional[Timber] = None,
+    **kwargs,
+):
     """
     Calculates the dry-weight biomass for individual trees in Sweden.
 
@@ -332,10 +628,19 @@ def Marklund_1988(species: Optional[str] = None, component: Optional[str] = None
         {'stem': 148.8, 'stump': 34.6, 'roots_1mm': 30.0}
 
         >>> # Calculate biomass for a Scots pine with DBH and height
-        >>> Marklund_1988_biomass_Sweden(species='Pinus sylvestris', DBH=25, height_m=18)
-        {'stem': 234.1, 'bark': 30.5, 'living_branches': 45.2, 'dead_branches': 5.1, 'stump': 55.7, 'roots_1mm': 49.8}
+        >>> Marklund_1988_biomass_Sweden(
+        ...     species='Pinus sylvestris', DBH=25, height_m=18
+        ... )
+        {
+            'stem': 234.1,
+            'bark': 30.5,
+            'living_branches': 45.2,
+            'dead_branches': 5.1,
+            'stump': 55.7,
+            'roots_1mm': 49.8,
+        }
     """
-    
+
     # Handle Timber object as the first argument if provided
     if isinstance(species, Timber):
         timber = species
@@ -345,10 +650,10 @@ def Marklund_1988(species: Optional[str] = None, component: Optional[str] = None
         timber.validate()
         species = timber.species
         component_args = {
-            'diameter_cm': timber.diameter_cm,
-            'height_m': timber.height_m,
-            'double_bark_mm': timber.double_bark_mm,
-            'crown_base_height_m': timber.crown_base_height_m
+            "diameter_cm": timber.diameter_cm,
+            "height_m": timber.height_m,
+            "double_bark_mm": timber.double_bark_mm,
+            "crown_base_height_m": timber.crown_base_height_m,
         }
         kwargs.update({k: v for k, v in component_args.items() if v is not None})
 
@@ -365,7 +670,9 @@ def Marklund_1988(species: Optional[str] = None, component: Optional[str] = None
         functions = species_map[species][component]
         for func in functions:
             try:
-                return func(**kwargs)
+                params = inspect.signature(func).parameters
+                call_kwargs = {k: v for k, v in kwargs.items() if k in params}
+                return func(**call_kwargs)
             except TypeError:
                 continue
         raise ValueError("No function matched the provided arguments.")
@@ -375,7 +682,9 @@ def Marklund_1988(species: Optional[str] = None, component: Optional[str] = None
         for comp, functions in species_map[species].items():
             for func in functions:
                 try:
-                    results[comp] = func(**kwargs)
+                    params = inspect.signature(func).parameters
+                    call_kwargs = {k: v for k, v in kwargs.items() if k in params}
+                    results[comp] = func(**call_kwargs)
                     break
                 except TypeError:
                     continue

--- a/src/pyforestry/sweden/siteindex/translate/hagglund_1981_si_to_productivity.py
+++ b/src/pyforestry/sweden/siteindex/translate/hagglund_1981_si_to_productivity.py
@@ -1,21 +1,24 @@
 # codefolder/MaximumAnnualIncrement.py (Modification)
 from pyforestry.base.helpers.primitives import SiteIndexValue
-from pyforestry.base.helpers.tree_species import TreeSpecies, TreeName
-from pyforestry.sweden.site.swedish_site import Sweden
+from pyforestry.base.helpers.tree_species import TreeName, TreeSpecies
+from pyforestry.sweden.site.enums import Sweden
+
 
 def hagglund_1981_SI_to_productivity(
     h100_input: SiteIndexValue,
     main_species: TreeName,
     vegetation: Sweden.FieldLayer,
     altitude: float,
-    county: Sweden.County # Changed type hint to the Enum
+    county: Sweden.County,  # Changed type hint to the Enum
 ) -> float:
     """
     Calculate smoothed productivity estimates in m3sk (cu.m.) from Hägglund 1981.
 
     Parameters:
-        h100_input (SiteIndexValue): Estimated stand top height object (must be H100, i.e., reference_age value must be 100).
-        main_species (TreeName): Main species (e.g., TreeSpecies.Sweden.picea_abies).
+        h100_input (SiteIndexValue):
+            Estimated stand top height object. Must be H100, meaning
+            ``reference_age`` equals 100.
+        main_species (TreeName): Main species (e.g., ``TreeSpecies.Sweden.picea_abies``).
         vegetation (Sweden.FieldLayer): Vegetation enum member.
         altitude (float): Altitude in meters above sea level.
         county (Sweden.County): Swedish county enum member.
@@ -38,38 +41,41 @@ def hagglund_1981_SI_to_productivity(
         Sweden.County.VASTERNORRLAND_MEDELPADS,
         Sweden.County.JAMTLAND_JAMTLANDS,
         Sweden.County.JAMTLAND_HARJEDALENS,
-        Sweden.County.KOPPARBERG_SALEN_IDRE
+        Sweden.County.KOPPARBERG_SALEN_IDRE,
     }
 
     MIDDLE_COUNTY_CODES = {
         Sweden.County.KOPPARBERG_OVRIGA,
         Sweden.County.GAVLEBORG_HALSINGLANDS,
         Sweden.County.GAVLEBORG_OVRIGA,
-        Sweden.County.VARMLAND    
+        Sweden.County.VARMLAND,
     }
 
     # Validate inputs
     # Check if the numeric value of the reference_age is 100
     if h100_input.reference_age != 100:
-         # Raise ValueError instead of warning
-         raise ValueError(f"Input SiteIndexValue must have a reference_age value of 100 (H100). Received: {h100_input.reference_age}") #
+        # Raise ValueError instead of warning
+        raise ValueError(
+            "Input SiteIndexValue must have a reference_age value of 100 (H100). "
+            f"Received: {h100_input.reference_age}"
+        )
 
-    H100 = float(h100_input) # Extract the float value for calculations
+    H100 = float(h100_input)  # Extract the float value for calculations
     if H100 <= 0:
-        raise ValueError("H100 value must be positive.") #
+        raise ValueError("H100 value must be positive.")  #
 
     if not isinstance(main_species, TreeName):
-         raise TypeError("main_species must be a TreeName object.") #
+        raise TypeError("main_species must be a TreeName object.")  #
 
     if not isinstance(vegetation, Sweden.FieldLayer):
-        raise TypeError("vegetation must be a Sweden.FieldLayer enum member.") #
+        raise TypeError("vegetation must be a Sweden.FieldLayer enum member.")  #
 
     if not isinstance(county, Sweden.County):
-        raise TypeError("county must be a Sweden.County enum member.") #
+        raise TypeError("county must be a Sweden.County enum member.")  #
 
     # --- rest of the function remains the same ---
     veg_code = vegetation.value.code
-    county_code = county.value.code # Get the integer code from the enum
+    county_code = county.value.code  # Get the integer code from the enum
 
     F1 = 0.72 + (H100 / 130)
     F2 = 0.70 + (H100 / 100)
@@ -81,7 +87,7 @@ def hagglund_1981_SI_to_productivity(
             fun = "d" if veg_code <= 9 else "e"
         elif county_code in MIDDLE_COUNTY_CODES:
             fun = "b" if veg_code <= 9 else "c"
-        else: # Southern Sweden assumed otherwise
+        else:  # Southern Sweden assumed otherwise
             fun = "a"
     elif main_species == TreeSpecies.Sweden.pinus_sylvestris:
         # For Pine: Northern Sweden with altitude >= 200 meters
@@ -89,24 +95,27 @@ def hagglund_1981_SI_to_productivity(
 
     if fun is None:
         # Use county label in error message for clarity
-        raise TypeError(f"Unrecognized combination for species {main_species.full_name}, county {county.value.label}, veg_code {veg_code}")
+        raise TypeError(
+            "Unrecognized combination for species "
+            f"{main_species.full_name}, county {county.value.label}, veg_code {veg_code}"
+        )
 
     # Calculate bonitet (same logic as before)
     bon = 0.0
     if fun == "a":
-        bon = (0.57207 + 0.22166 * H100 + 0.0050164 * H100 ** 2) * F1
+        bon = (0.57207 + 0.22166 * H100 + 0.0050164 * H100**2) * F1
     elif fun == "b":
-        bon = (1.28417 + 0.31060 * H100 + 0.0020048 * H100 ** 2) * F1
+        bon = (1.28417 + 0.31060 * H100 + 0.0020048 * H100**2) * F1
     elif fun == "c":
-        bon = (-0.42289 + 0.17735 * H100 + 0.0050580 * H100 ** 2) * F1
+        bon = (-0.42289 + 0.17735 * H100 + 0.0050580 * H100**2) * F1
     elif fun == "d":
-        bon = (-0.75761 + 0.24393 * H100 + 0.0014564 * H100 ** 2) * F2
+        bon = (-0.75761 + 0.24393 * H100 + 0.0014564 * H100**2) * F2
     elif fun == "e":
-        bon = (-0.59224 + 0.21765 * H100 + 0.0011391 * H100 ** 2) * F2
+        bon = (-0.59224 + 0.21765 * H100 + 0.0011391 * H100**2) * F2
     elif fun == "f":
-        bon = (-0.39456 + 0.16469 * H100 + 0.0047191 * H100 ** 2) * F2
+        bon = (-0.39456 + 0.16469 * H100 + 0.0047191 * H100**2) * F2
     elif fun == "g":
-        bon = (0.099227 + 0.067873 * H100 + 0.0066316 * H100 ** 2) * F2
+        bon = (0.099227 + 0.067873 * H100 + 0.0066316 * H100**2) * F2
     else:
         raise TypeError(f"Internal error: function code '{fun}' not recognized.")
 


### PR DESCRIPTION
## Summary
- avoid importing Sweden enum through `swedish_site` to break a circular import
- filter kwargs in Marklund biomass helper

## Testing
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`
- `cd docs && make html`

------
https://chatgpt.com/codex/tasks/task_e_6879325682c48329abc2926d2306474e