### PR TITLE
Implement Stand thinning feature

### DIFF
--- a/src/pyforestry/base/helpers/tree.py
+++ b/src/pyforestry/base/helpers/tree.py
@@ -2,14 +2,17 @@
 # Tree classes
 # ------------------------------------------------------------------------------
 from typing import Optional, Union
+
+from .primitives import Age, Diameter_cm, Position
 from .tree_species import TreeName, parse_tree_species
-from .primitives import Position, Diameter_cm, Age 
+
 
 class Tree:
     """
     Base class for all tree objects. You can expand this to include common fields/methods
     that should exist on any type of tree.
     """
+
     pass
 
 
@@ -30,12 +33,16 @@ class SingleTree(Tree):
     height_m : float | None
         The height (m) of the tree if known.
     """
-    def __init__(self,
-                 position: Optional[Union[Position, tuple, None]] = None,
-                 species: Optional[Union[TreeName, str]] = None,
-                 age: Optional[Union[Age, float]] = None,
-                 diameter_cm: Optional[Union[Diameter_cm, float]] = None,
-                 height_m: Optional[float] = None):
+
+    def __init__(
+        self,
+        position: Optional[Union[Position, tuple, None]] = None,
+        species: Optional[Union[TreeName, str]] = None,
+        age: Optional[Union[Age, float]] = None,
+        diameter_cm: Optional[Union[Diameter_cm, float]] = None,
+        height_m: Optional[float] = None,
+        uid: Optional[Union[int, str]] = None,
+    ):
         self.position = Position._set_position(position)
 
         # Convert string species → TreeSpecies if parseable
@@ -52,11 +59,14 @@ class SingleTree(Tree):
         # or just store as float. For now, store as given:
         self.diameter_cm = diameter_cm
         self.height_m = height_m
+        self.uid = uid
 
     def __repr__(self):
-        return (f"SingleTree(species={self.species}, age={self.age}, "
-                f"diameter_cm={self.diameter_cm}, height_m={self.height_m}, "
-                f"position={self.position})")
+        return (
+            f"SingleTree(species={self.species}, age={self.age}, "
+            f"diameter_cm={self.diameter_cm}, height_m={self.height_m}, "
+            f"position={self.position}, uid={self.uid})"
+        )
 
 
 class RepresentationTree(Tree):
@@ -79,13 +89,17 @@ class RepresentationTree(Tree):
     weight : float
         Number of stems represented by this single record (e.g. 1, or 5).
     """
-    def __init__(self,
-                 position: Optional[Union[Position, tuple, None]] = None,
-                 species: Optional[Union[TreeName, str]] = None,
-                 age: Optional[Union[Age, float]] = None,
-                 diameter_cm: Optional[Union[Diameter_cm, float]] = None,
-                 height_m: Optional[float] = None,
-                 weight: float = 1.0):
+
+    def __init__(
+        self,
+        position: Optional[Union[Position, tuple, None]] = None,
+        species: Optional[Union[TreeName, str]] = None,
+        age: Optional[Union[Age, float]] = None,
+        diameter_cm: Optional[Union[Diameter_cm, float]] = None,
+        height_m: Optional[float] = None,
+        weight: float = 1.0,
+        uid: Optional[Union[int, str]] = None,
+    ):
         self.position = Position._set_position(position)
 
         if isinstance(species, str):
@@ -97,7 +111,11 @@ class RepresentationTree(Tree):
         self.diameter_cm = diameter_cm
         self.height_m = height_m
         self.weight = weight
+        self.uid = uid
 
     def __repr__(self):
-        return (f"RepresentationTree(species={self.species}, age={self.age}, "
-                f"diameter_cm={self.diameter_cm}, height_m={self.height_m}, weight={self.weight})")
+        return (
+            f"RepresentationTree(species={self.species}, age={self.age}, "
+            f"diameter_cm={self.diameter_cm}, height_m={self.height_m}, "
+            f"weight={self.weight}, uid={self.uid})"
+        )

--- a/tests/base/test_stand_plot.py
+++ b/tests/base/test_stand_plot.py
@@ -31,6 +31,7 @@ def test_diameter_cm():
     with pytest.raises(ValueError):
         Diameter_cm(-10)  # negative diameter
 
+
 def test_CircularPlot_init_ok():
     """Test creating a CircularPlot with valid radius or area."""
     p1 = CircularPlot(id=1, radius_m=5.0)
@@ -41,10 +42,12 @@ def test_CircularPlot_init_ok():
     assert math.isclose(p2.radius_m, 10, rel_tol=1e-3) is True
     assert p2.area_ha == p2.area_m2 / 10000
 
+
 def test_CircularPlot_init_fail():
     """CircularPlot must have radius_m or area_m2."""
     with pytest.raises(ValueError):
         CircularPlot(id=3)
+
 
 def test_stand_basic():
     """Create a Stand with no polygon or area. Should be allowed."""
@@ -52,19 +55,21 @@ def test_stand_basic():
     assert s.area_ha is None
     assert len(s.plots) == 0
 
+
 def test_stand_polygon_area():
     """Check polygon-based area computation."""
     # A simple square polygon 100 x 100 => 10000 m² => 1.0 ha
-    poly = Polygon([(0,0),(100,0),(100,100),(0,100)])
-    st = Stand(polygon=poly,crs=CRS('EPSG:3006'))
+    poly = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    st = Stand(polygon=poly, crs=CRS("EPSG:3006"))
     assert st.area_ha is not None
     assert math.isclose(st.area_ha, 1.0, rel_tol=1e-3)
+
 
 def test_stand_polygon_mismatch_value_error():
     """Check that a mismatch in user area_ha vs. polygon area triggers a ValueError."""
     poly = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])  # 10000 m² => 1 ha
-    with pytest.raises(ValueError, match='Polygon area is 1.00 ha, but you set area_ha=2.00 ha.'):
-        Stand(polygon=poly, crs=CRS('EPSG:3006'), area_ha=2.0)
+    with pytest.raises(ValueError, match="Polygon area is 1.00 ha, but you set area_ha=2.00 ha."):
+        Stand(polygon=poly, crs=CRS("EPSG:3006"), area_ha=2.0)
 
 
 def test_stand_metric_calculations():
@@ -73,18 +78,26 @@ def test_stand_metric_calculations():
     sp_pinus = parse_tree_species("pinus sylvestris")
 
     # Create a couple of CircularPlots
-    pl1 = CircularPlot(id=1, radius_m=5.0, trees=[
-        RepresentationTree(species=sp_picea, diameter_cm=25, weight=2),
-        RepresentationTree(species=sp_pinus, diameter_cm=30, weight=1)
-    ])
-    pl2 = CircularPlot(id=2, radius_m=5.0, trees=[
-        RepresentationTree(species=sp_picea, diameter_cm=20, weight=1),
-        RepresentationTree(species=sp_pinus, diameter_cm=35, weight=2)
-    ])
+    pl1 = CircularPlot(
+        id=1,
+        radius_m=5.0,
+        trees=[
+            RepresentationTree(species=sp_picea, diameter_cm=25, weight=2),
+            RepresentationTree(species=sp_pinus, diameter_cm=30, weight=1),
+        ],
+    )
+    pl2 = CircularPlot(
+        id=2,
+        radius_m=5.0,
+        trees=[
+            RepresentationTree(species=sp_picea, diameter_cm=20, weight=1),
+            RepresentationTree(species=sp_pinus, diameter_cm=35, weight=2),
+        ],
+    )
     st = Stand(plots=[pl1, pl2])
     # Force compute:
     val_stems_total = float(st.Stems)
-    val_ba_total    = float(st.BasalArea)
+    val_ba_total = float(st.BasalArea)
 
     # We won't assert the exact numbers too strictly, but we can check they're >0
     assert val_stems_total > 0
@@ -96,16 +109,19 @@ def test_stand_metric_calculations():
     assert ba_picea.value > 0
     assert ba_pinus.value > 0
 
+
 def test_stand_metric_accessor_keyerror():
     """If we request a species that doesn't exist, we get a KeyError."""
     st = Stand(plots=[])
     with pytest.raises(KeyError):
         st.BasalArea("picea abies")
 
+
 def test_CircularPlot_area_ha_property():
     """Simple test of the CircularPlot area_ha property."""
     p = CircularPlot(id=10, radius_m=10)
-    assert math.isclose(p.area_ha, math.pi*100 / 10000, rel_tol=1e-7)
+    assert math.isclose(p.area_ha, math.pi * 100 / 10000, rel_tol=1e-7)
+
 
 def test_representation_tree_defaults():
     """Check default values for RepresentationTree."""
@@ -115,12 +131,14 @@ def test_representation_tree_defaults():
     assert tr.height_m is None
     assert tr.weight == 1.0
 
+
 def test_representation_tree_with_string_species():
     """Check that a string species is parsed to a TreeName."""
     tr = RepresentationTree(species="picea abies", diameter_cm=25.0)
     assert tr.species is not None
     assert tr.species.genus.name == "Picea"
     assert tr.species.species_name == "abies"
+
 
 def test_stems_basalarea_objects():
     """Check that Stems and StandBasalArea store their attributes properly."""
@@ -135,6 +153,7 @@ def test_stems_basalarea_objects():
     assert ba.species == sp
     assert ba.precision == 2.5
 
+
 def test_stems_basalarea_negatives():
     """Ensure negative values are disallowed."""
     with pytest.raises(ValueError):
@@ -143,12 +162,14 @@ def test_stems_basalarea_negatives():
     with pytest.raises(ValueError):
         StandBasalArea(-5)
 
+
 def test_metric_value_property():
-    ba = StandBasalArea(30.0, species=parse_tree_species('picea abies'), precision=2.5)
-    s = Stems(100, species=parse_tree_species('picea abies'), precision=5)
+    ba = StandBasalArea(30.0, species=parse_tree_species("picea abies"), precision=2.5)
+    s = Stems(100, species=parse_tree_species("picea abies"), precision=5)
     # Using the .value property we added
     assert ba.value == 30.0
     assert s.value == 100
+
 
 # --- AngleCount add_observation tests ---
 def test_angle_count_add_observation():
@@ -157,6 +178,7 @@ def test_angle_count_add_observation():
     ac.add_observation(sp1, 2)
     # Expecting 1 + 2 = 3 for the first (and only) species entry
     assert ac.value[0] == 3
+
 
 # --- AngleCount merging tests ---
 # Corrected test_angle_count_merging
@@ -170,6 +192,7 @@ def test_angle_count_merging():
     assert len(merged) == 1
     merged_record = merged[0]
     assert math.isclose(merged_record.value[0], 10)
+
 
 # --- Aggregate stand metrics tests ---
 def test_aggregate_stand_metrics():
@@ -197,9 +220,10 @@ def test_aggregate_stand_metrics():
 
 # --- Volume conversion tests ---
 def test_volume_conversion():
-    vol = AtomicVolume(1, region="Sweden", species="Picea_abies",type='m3sk')
+    vol = AtomicVolume(1, region="Sweden", species="Picea_abies", type="m3sk")
     # 1 m3 = 1000 dm3
-    assert math.isclose(vol.to('dm3'), 1000, rel_tol=1e-6)
+    assert math.isclose(vol.to("dm3"), 1000, rel_tol=1e-6)
+
 
 # --- Dominant height measurement test ---
 def test_get_dominant_height():
@@ -216,10 +240,12 @@ def test_get_dominant_height():
     assert dominant_height is not None
     assert dominant_height > 0
 
+
 # --- Negative diameter test ---
 def test_negative_diameter_error():
     with pytest.raises(ValueError):
         Diameter_cm(-5)
+
 
 # --- Multiple AngleCount objects in a CircularPlot ---
 # Corrected test_multiple_angle_counts_in_plot
@@ -233,6 +259,7 @@ def test_multiple_angle_counts_in_plot():
     # With summing: 3 + 5 = 8
     assert len(merged) == 1
     assert math.isclose(merged[0].value[0], 8)
+
 
 # --- StandMetricAccessor species key error test ---
 def test_stand_metric_accessor_species_keyerror():
@@ -263,10 +290,12 @@ def test_qmd_recomputes_after_append_plot():
 
 # --- Test H-T estimator with RepresentationTrees ---
 
+
 # Use the existing diameter-height relation from the bias function:
 def compute_height(d_cm: float) -> float:
     d_m = d_cm / 100.0
-    return 1.3 + (d_m ** 2) / ((1.1138 + 0.2075 * d_m) ** 2)
+    return 1.3 + (d_m**2) / ((1.1138 + 0.2075 * d_m) ** 2)
+
 
 def test_random_plots_on_stand():
     # Define a rectangular stand (200 m x 100 m)
@@ -283,7 +312,7 @@ def test_random_plots_on_stand():
     d_picea = 10  # cm
     h_pinus = compute_height(d_pinus)
     h_picea = compute_height(d_picea)
-    density_pinus = 600   # trees per ha
+    density_pinus = 600  # trees per ha
     density_picea = 1200  # trees per ha
 
     plots = []
@@ -299,9 +328,9 @@ def test_random_plots_on_stand():
         intersection = circle.intersection(stand_polygon)
         intersection_area = intersection.area
         # Occlusion: fraction of plot outside the stand.
-        occlusion = max(0.0,min(1 - (intersection_area / area_circle),0.9999))
+        occlusion = max(0.0, min(1 - (intersection_area / area_circle), 0.9999))
         # Create the plot. (The constructor requires occlusion to be in [0, 1))
-        plot = CircularPlot(id=i+1, position=pos, radius_m=r, occlusion=occlusion)
+        plot = CircularPlot(id=i + 1, position=pos, radius_m=r, occlusion=occlusion)
 
         # Calculate the effective plot area in hectares:
         plot_area_ha = plot.area_ha  # total plot area in ha
@@ -315,19 +344,23 @@ def test_random_plots_on_stand():
         # Create RepresentationTree objects for each species.
         trees = []
         for _ in range(n_pinus):
-            trees.append(RepresentationTree(
-                species=TreeSpecies.Sweden.pinus_sylvestris,
-                diameter_cm=d_pinus,
-                height_m=h_pinus,
-                weight=1.0
-            ))
+            trees.append(
+                RepresentationTree(
+                    species=TreeSpecies.Sweden.pinus_sylvestris,
+                    diameter_cm=d_pinus,
+                    height_m=h_pinus,
+                    weight=1.0,
+                )
+            )
         for _ in range(n_picea):
-            trees.append(RepresentationTree(
-                species=TreeSpecies.Sweden.picea_abies,
-                diameter_cm=d_picea,
-                height_m=h_picea,
-                weight=1.0
-            ))
+            trees.append(
+                RepresentationTree(
+                    species=TreeSpecies.Sweden.picea_abies,
+                    diameter_cm=d_picea,
+                    height_m=h_picea,
+                    weight=1.0,
+                )
+            )
         plot.trees = trees
         plots.append(plot)
 
@@ -363,8 +396,35 @@ def test_random_plots_on_stand():
     assert top_height is not None
     assert top_height.value > 0
     assert qmd_total.value > 0
-    assert qmd_total.precision >0
+    assert qmd_total.precision > 0
     assert qmd_picea.value > 0
     assert qmd_picea.precision > 0
     assert qmd_pinus.value > 0
     assert qmd_pinus.precision > 0
+
+
+def test_thin_by_uid():
+    sp = parse_tree_species("picea abies")
+    t1 = RepresentationTree(species=sp, diameter_cm=20, uid="A")
+    t2 = RepresentationTree(species=sp, diameter_cm=25, uid="B")
+    plot = CircularPlot(id=1, radius_m=5, trees=[t1, t2])
+    stand = Stand(plots=[plot])
+
+    assert len(stand.plots[0].trees) == 2
+    stand.thin_trees(uids=["A"])
+    assert len(stand.plots[0].trees) == 1
+    assert stand.plots[0].trees[0].uid == "B"
+
+
+def test_thin_by_rule_and_polygon():
+    sp = parse_tree_species("picea abies")
+    inside = RepresentationTree(species=sp, diameter_cm=30, position=Position(0, 0), uid=1)
+    outside = RepresentationTree(species=sp, diameter_cm=30, position=Position(100, 0), uid=2)
+    plot = CircularPlot(id=1, radius_m=5, trees=[inside, outside])
+    stand = Stand(plots=[plot])
+
+    poly = Polygon([(-10, -10), (10, -10), (10, 10), (-10, 10)])
+    stand.thin_trees(rule=lambda t: t.diameter_cm and t.diameter_cm > 25, polygon=poly)
+
+    assert len(stand.plots[0].trees) == 1
+    assert stand.plots[0].trees[0].uid == 2


### PR DESCRIPTION
## Summary
- extend `RepresentationTree` and `SingleTree` with optional `uid` attribute
- add `Stand.thin_trees` for thinning by uid, rule or spatial polygon
- test thinning functionality

## Testing
- `ruff check src/pyforestry/base/helpers/tree.py src/pyforestry/base/helpers/stand.py tests/base/test_stand_plot.py --fix`
- `black src/pyforestry/base/helpers/tree.py src/pyforestry/base/helpers/stand.py tests/base/test_stand_plot.py`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`

------
https://chatgpt.com/codex/tasks/task_e_687943b73f1083299fefb75699527335