### PR TITLE
Improve module documentation

### DIFF
--- a/src/pyforestry/__init__.py
+++ b/src/pyforestry/__init__.py
@@ -1,2 +1,3 @@
-from . import base
-from . import sweden
+"""Top-level package for pyforestry."""
+
+from . import base, sweden

--- a/src/pyforestry/base/pricelist/__init__.py
+++ b/src/pyforestry/base/pricelist/__init__.py
@@ -1,2 +1,4 @@
+"""Public API for pricelist utilities."""
+
 from .pricelist import *
 from .solutioncube import *

--- a/src/pyforestry/base/pricelist/data/__init__.py
+++ b/src/pyforestry/base/pricelist/data/__init__.py
@@ -1,1 +1,3 @@
+"""Price list datasets used for economic calculations."""
+
 from .mellanskog_2013 import Mellanskog_2013_price_data

--- a/src/pyforestry/base/pricelist/data/mellanskog_2013.py
+++ b/src/pyforestry/base/pricelist/data/mellanskog_2013.py
@@ -1,4 +1,5 @@
-# Example structured data for easy readability and maintenance
+"""Example price list data from Mellanskog's 2013 tables."""
+
 # Use of TreeSpecies shorthand to avoid typos and situations e.g. Betula != Betula pendula.
 
 from pyforestry.base.helpers.tree_species import TreeSpecies
@@ -13,7 +14,7 @@ Mellanskog_2013_price_data = {
         "PulpwoodPrices": {
             TreeSpecies.Sweden.pinus_sylvestris.full_name: 250,
             TreeSpecies.Sweden.picea_abies.full_name: 265,
-            TreeSpecies.Sweden.betula.full_name: 250
+            TreeSpecies.Sweden.betula.full_name: 250,
         },
         "PulpwoodCullProportion": 0.05,
         "FuelwoodProportion": 0.0,
@@ -21,9 +22,8 @@ Mellanskog_2013_price_data = {
         "FuelwoodLogPrice": 200,
         "StumpPrice": 380,
         "ApplyPriceTrends": False,
-        "HighStumpHeight": 4
+        "HighStumpHeight": 4,
     },
-
     TreeSpecies.Sweden.pinus_sylvestris.full_name: {
         "VolumeType": "m3to",
         "DiameterPrices": {
@@ -46,16 +46,13 @@ Mellanskog_2013_price_data = {
             14: {34: 80, 37: 85, 40: 90, 43: 95, 46: 100, 49: 102, 52: 104, 55: 106}
         },
         "QualityOutcome": {
-            "Butt":   [0.31, 0.00, 0.57, 0.12],
+            "Butt": [0.31, 0.00, 0.57, 0.12],
             "Middle": [0.00, 0.31, 0.57, 0.12],
-            "Top":    [0.00, 0.31, 0.57, 0.12],
+            "Top": [0.00, 0.31, 0.57, 0.12],
         },
-        "DowngradeProportions": {
-            "Pulpwood": 0.10, "Fuelwood": 0.0, "HarvestResidue": 0.02
-        },
-        "MaxHeight": {"Butt": 5.5, "Middle": 11.0, "Top": 99.0}
+        "DowngradeProportions": {"Pulpwood": 0.10, "Fuelwood": 0.0, "HarvestResidue": 0.02},
+        "MaxHeight": {"Butt": 5.5, "Middle": 11.0, "Top": 99.0},
     },
-
     TreeSpecies.Sweden.picea_abies.full_name: {
         "VolumeType": "m3to",
         "DiameterPrices": {
@@ -78,13 +75,11 @@ Mellanskog_2013_price_data = {
             14: {34: 80, 37: 85, 40: 90, 43: 95, 46: 100, 49: 102, 52: 104, 55: 106}
         },
         "QualityOutcome": {
-            "Butt":   [0.86, 0.14],
+            "Butt": [0.86, 0.14],
             "Middle": [0.86, 0.14],
-            "Top":    [0.86, 0.14],
+            "Top": [0.86, 0.14],
         },
-        "DowngradeProportions": {
-            "Pulpwood": 0.10, "Fuelwood": 0.0, "HarvestResidue": 0.02
-        },
-        "MaxHeight": {"Butt": 5.5, "Middle": 11.0, "Top": 99.0}
-    }
+        "DowngradeProportions": {"Pulpwood": 0.10, "Fuelwood": 0.0, "HarvestResidue": 0.02},
+        "MaxHeight": {"Butt": 5.5, "Middle": 11.0, "Top": 99.0},
+    },
 }

--- a/src/pyforestry/base/taper/__init__.py
+++ b/src/pyforestry/base/taper/__init__.py
@@ -1,5 +1,5 @@
+"""Base taper models used to describe stem profiles."""
+
 from .taper import Taper
 
-__all__ = [
-    "Taper"
-]
+__all__ = ["Taper"]

--- a/src/pyforestry/base/timber/__init__.py
+++ b/src/pyforestry/base/timber/__init__.py
@@ -1,3 +1,5 @@
+"""Convenience re-exports for timber classes."""
+
 from .timber_base import *
 
-__all__ = ['Timber', 'TimberVolumeIntegrator']
+__all__ = ["Timber", "TimberVolumeIntegrator"]

--- a/src/pyforestry/base/timber/timber_base/timber.py
+++ b/src/pyforestry/base/timber/timber_base/timber.py
@@ -1,6 +1,11 @@
+"""Basic container class for individual tree parameters."""
+
 from typing import Optional
 
+
 class Timber:
+    """Representation of a single tree with minimal attributes."""
+
     def __init__(
         self,
         species: str,
@@ -9,7 +14,7 @@ class Timber:
         double_bark_mm: Optional[float] = None,
         crown_base_height_m: Optional[float] = None,
         over_bark: Optional[bool] = None,
-        stump_height_m: Optional[float] = 0.3
+        stump_height_m: Optional[float] = 0.3,
     ):
         self.species = species.lower()
         self.diameter_cm = diameter_cm
@@ -21,16 +26,26 @@ class Timber:
 
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
+        """Validate that the provided tree attributes are sensible."""
 
         if self.height_m <= 0:
-            raise ValueError('Height must be larger than 0 m: {self.height_m}')
+            raise ValueError("Height must be larger than 0 m: {self.height_m}")
 
         if self.diameter_cm < 0:
             raise ValueError("Diameter must be larger or equal to than 0 cm: {self.diameter_cm}")
 
-        if self.crown_base_height_m is not None and self.height_m is not None and self.crown_base_height_m >= self.height_m:
-            raise ValueError(f'Crown base height ({self.crown_base_height_m} m) cannot be higher than tree height: {self.height_m} m')
-        
+        if (
+            self.crown_base_height_m is not None
+            and self.height_m is not None
+            and self.crown_base_height_m >= self.height_m
+        ):
+            raise ValueError(
+                (
+                    f"Crown base height ({self.crown_base_height_m} m) cannot be "
+                    f"higher than tree height: {self.height_m} m"
+                )
+            )
+
         if self.stump_height_m is not None and self.stump_height_m < 0:
-            raise ValueError(f'Stump height must be larger or equal to 0 m: {self.stump_height_m}')
+            raise ValueError(f"Stump height must be larger or equal to 0 m: {self.stump_height_m}")

--- a/src/pyforestry/base/timber_bucking/bucker.py
+++ b/src/pyforestry/base/timber_bucking/bucker.py
@@ -1,3 +1,8 @@
+"""Base class for log bucking algorithms."""
+
+
 class Bucker:
-    def __init__(self):
-        pass
+    """Simple base class for bucking implementations."""
+
+    def __init__(self) -> None:
+        """Initialize a new bucker instance."""

--- a/src/pyforestry/sweden/site/sweden_site_primitives.py
+++ b/src/pyforestry/sweden/site/sweden_site_primitives.py
@@ -1,8 +1,12 @@
+"""Dataclasses defining Swedish site classification codes."""
+
 from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
 class Vegetation:
+    """Vegetation type with a productivity index."""
+
     code: int
     swedish_name: str
     english_name: str
@@ -11,6 +15,8 @@ class Vegetation:
 
 @dataclass(frozen=True)
 class BottomLayerType:
+    """Main ground vegetation category."""
+
     code: int
     english_name: str
     swedish_name: str
@@ -18,6 +24,8 @@ class BottomLayerType:
 
 @dataclass(frozen=True)
 class SoilWaterCat:
+    """Qualitative class describing soil water availability."""
+
     code: int
     swedish_description: str
     english_description: str
@@ -25,6 +33,8 @@ class SoilWaterCat:
 
 @dataclass(frozen=True)
 class SoilDepthCat:
+    """Categorical depth to parent material."""
+
     code: int
     swedish_description: str
     english_description: str
@@ -32,6 +42,8 @@ class SoilDepthCat:
 
 @dataclass(frozen=True)
 class SoilTextureCategory:
+    """Soil texture group such as clay or sand."""
+
     code: int
     swedish_name: str
     english_name: str
@@ -40,6 +52,8 @@ class SoilTextureCategory:
 
 @dataclass(frozen=True)
 class SoilMoistureData:
+    """Relative soil moisture description."""
+
     code: int
     swedish_description: str
     english_description: str
@@ -47,6 +61,8 @@ class SoilMoistureData:
 
 @dataclass(frozen=True)
 class PeatHumificationCat:
+    """Degree of humification for peat soils."""
+
     code: int
     swedish_description: str
     english_description: str
@@ -54,12 +70,16 @@ class PeatHumificationCat:
 
 @dataclass(frozen=True)
 class CountyData:
+    """Swedish county identifier."""
+
     code: int
     label: str  # Descriptive string label
 
 
 @dataclass(frozen=True)
 class ClimateZoneData:
+    """Zonal climate classification."""
+
     code: int
     label: str  # e.g., "M1", "K2"
     description: str  # Descriptive name


### PR DESCRIPTION
## Summary
- add module docstring in root package
- add docstrings for several timber and pricelist modules
- document Swedish site data classes

## Testing
- `ruff check src/pyforestry/base/taper/__init__.py src/pyforestry/base/timber_bucking/bucker.py src/pyforestry/base/pricelist/data/__init__.py src/pyforestry/base/pricelist/data/mellanskog_2013.py src/pyforestry/base/timber/timber_base/timber.py src/pyforestry/sweden/site/sweden_site_primitives.py src/pyforestry/base/timber/__init__.py src/pyforestry/base/pricelist/__init__.py src/pyforestry/__init__.py --fix`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`

------
https://chatgpt.com/codex/tasks/task_e_687944fcf66083299e7cc222abb8f87d