### PR TITLE
Add coverage tests

### DIFF
--- a/tests/base/test_cartesian_position.py
+++ b/tests/base/test_cartesian_position.py
@@ -1,0 +1,32 @@
+import math
+
+import pytest
+
+from pyforestry.base.helpers.primitives.cartesian_position import Position
+
+
+def test_from_polar_and_repr():
+    pos = Position.from_polar(1.0, math.pi / 2)
+    assert pytest.approx(pos.X, rel=1e-6) == 0.0
+    assert pytest.approx(pos.Y, rel=1e-6) == 1.0
+    assert pos.Z == 0.0
+    assert pos.crs is None
+    assert repr(pos) == f"Position(X={pos.X}, Y={pos.Y}, Z={pos.Z}, crs={pos.crs})"
+
+
+def test_set_position_variants():
+    pos = Position(1, 2, 3)
+    assert Position._set_position(pos) is pos
+    assert Position._set_position(None) is None
+
+    pos_xy = Position._set_position((4, 5))
+    assert isinstance(pos_xy, Position)
+    assert pos_xy.X == 4 and pos_xy.Y == 5 and pos_xy.Z == 0.0
+
+    pos_xyz = Position._set_position((6, 7, 8))
+    assert pos_xyz.Z == 8
+
+    with pytest.raises(ValueError):
+        Position._set_position((1, 2, 3, 4))
+    with pytest.raises(TypeError):
+        Position._set_position([1, 2])

--- a/tests/base/test_qmd.py
+++ b/tests/base/test_qmd.py
@@ -1,0 +1,26 @@
+import math
+
+import pytest
+
+from pyforestry.base.helpers.primitives.qmd import QuadraticMeanDiameter
+
+
+def test_qmd_compute_from_valid():
+    qmd = QuadraticMeanDiameter.compute_from(20, 500)
+    expected = math.sqrt((40000 * 20) / (math.pi * 500))
+    assert isinstance(qmd, QuadraticMeanDiameter)
+    assert math.isclose(qmd.value, expected, rel_tol=1e-6)
+
+
+def test_qmd_compute_from_invalid():
+    with pytest.raises(ValueError):
+        QuadraticMeanDiameter.compute_from(0, 100)
+    with pytest.raises(ValueError):
+        QuadraticMeanDiameter.compute_from(10, 0)
+
+
+def test_qmd_repr_and_negative():
+    qmd = QuadraticMeanDiameter(12.345, precision=0.5)
+    assert repr(qmd) == "QuadraticMeanDiameter(12.35 cm, precision=0.50 cm)"
+    with pytest.raises(ValueError):
+        QuadraticMeanDiameter(-1)

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+
+from pyforestry.base.helpers.utils import enum_code
+
+
+@dataclass
+class InnerCode:
+    code: int
+
+
+@dataclass
+class OuterValueCode:
+    value: InnerCode
+
+
+@dataclass
+class InnerLabel:
+    label: str
+
+
+@dataclass
+class OuterValueLabel:
+    value: InnerLabel
+
+
+class ClimateZoneData:
+    def __init__(self, label):
+        self.code = 1
+        self.label = label
+
+
+class OuterClimate:
+    def __init__(self, label):
+        self.value = ClimateZoneData(label)
+
+
+class ObjWithCode:
+    def __init__(self, code):
+        self.code = code
+
+
+class ObjWithLabel:
+    def __init__(self, label):
+        self.label = label
+
+
+def test_enum_code_from_value_code():
+    obj = OuterValueCode(InnerCode(5))
+    assert enum_code(obj) == 5
+
+
+def test_enum_code_from_value_label():
+    obj = OuterValueLabel(InnerLabel("foo"))
+    assert enum_code(obj) == "foo"
+
+
+def test_enum_code_climate_zone_like():
+    obj = OuterClimate("bar")
+    assert enum_code(obj) == "bar"
+
+
+def test_enum_code_direct_attributes():
+    assert enum_code(ObjWithCode(7)) == 7
+    assert enum_code(ObjWithLabel("baz")) == "baz"
+
+
+def test_enum_code_primitives():
+    assert enum_code(3) == 3
+    assert enum_code("hi") == "hi"

--- a/tests/sweden/test_translate.py
+++ b/tests/sweden/test_translate.py
@@ -1,0 +1,45 @@
+import math
+
+import pytest
+
+from pyforestry.sweden.siteindex.translate import (
+    Leijon_Pine_to_Spruce,
+    Leijon_Spruce_to_Pine,
+    agestam_1985_si_translation_pine_to_birch,
+    agestam_1985_si_translation_spruce_to_birch,
+)
+
+
+def test_leijon_pine_to_spruce_basic():
+    result = Leijon_Pine_to_Spruce(15)
+    expected = math.exp(-0.9596 * math.log(150) + 0.01171 * 150 + 7.9209) / 10
+    assert math.isclose(result, expected, rel_tol=1e-6)
+
+
+def test_leijon_pine_to_spruce_warning():
+    with pytest.warns(UserWarning):
+        Leijon_Pine_to_Spruce(5)
+
+
+def test_leijon_spruce_to_pine_basic():
+    result = Leijon_Spruce_to_Pine(20)
+    expected = math.exp(1.6967 * math.log(200) - 0.005179 * 200 - 2.5397) / 10
+    assert math.isclose(result, expected, rel_tol=1e-6)
+
+
+def test_leijon_spruce_to_pine_warning():
+    with pytest.warns(UserWarning):
+        Leijon_Spruce_to_Pine(40)
+
+
+def test_agestam_translations():
+    assert math.isclose(
+        agestam_1985_si_translation_pine_to_birch(20),
+        ((0.736 * (20 * 10)) - 21.1) / 10,
+        rel_tol=1e-6,
+    )
+    assert math.isclose(
+        agestam_1985_si_translation_spruce_to_birch(20),
+        ((0.382 * (20 * 10)) + 75.8) / 10,
+        rel_tol=1e-6,
+    )


### PR DESCRIPTION
## Summary
- add tests for cartesian positions and QMD primitives
- test enum_code utility
- cover siteindex translation helpers

## Testing
- `ruff check tests/base/test_cartesian_position.py tests/base/test_qmd.py tests/base/test_utils.py tests/sweden/test_translate.py --fix`
- `black tests/base/test_cartesian_position.py tests/base/test_qmd.py tests/base/test_utils.py tests/sweden/test_translate.py`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`

------
https://chatgpt.com/codex/tasks/task_e_6879450a4bd883298f3837a797eef2dc