### PR TITLE
Improve docstring coverage

### DIFF
--- a/src/pyforestry/base/helpers/__init__.py
+++ b/src/pyforestry/base/helpers/__init__.py
@@ -1,3 +1,5 @@
+"""Convenience imports for common helper types."""
+
 # Suggested pyforestry/Helpers/__init__.py
 # ruff: noqa: F401, F403, F405
 # isort: off

--- a/src/pyforestry/base/helpers/primitives/__init__.py
+++ b/src/pyforestry/base/helpers/primitives/__init__.py
@@ -1,9 +1,11 @@
+"""Expose typed primitive data structures used throughout the package."""
+
 from .age import Age, AgeMeasurement
+from .area_aggregates import StandBasalArea, StandVolume, Stems
 from .cartesian_position import Position
 from .diameter_cm import Diameter_cm
 from .qmd import QuadraticMeanDiameter
+from .sitebase import SiteBase
 from .siteindex_value import SiteIndexValue
-from .area_aggregates import StandBasalArea, StandVolume, Stems
 from .topheight import TopHeightDefinition, TopHeightMeasurement
 from .volume import AtomicVolume, CompositeVolume
-from .sitebase import SiteBase

--- a/src/pyforestry/base/helpers/utils.py
+++ b/src/pyforestry/base/helpers/utils.py
@@ -1,3 +1,5 @@
+"""Miscellaneous helper utilities."""
+
 from typing import Union
 
 

--- a/src/pyforestry/sweden/taper/__init__.py
+++ b/src/pyforestry/sweden/taper/__init__.py
@@ -1,2 +1,5 @@
+"""Public API for the taper models subpackage."""
+
 from .edgren_nylinder_1949 import EdgrenNylinder1949
-__all__ = ['EdgrenNylinder1949']
+
+__all__ = ["EdgrenNylinder1949"]

--- a/src/pyforestry/sweden/timber/__init__.py
+++ b/src/pyforestry/sweden/timber/__init__.py
@@ -1,5 +1,7 @@
+"""Entry points for Swedish timber functionality."""
+
 from .swe_timber import SweTimber
 
 __all__ = [
-    "SweTimber"
+    "SweTimber",
 ]

--- a/src/pyforestry/sweden/timber/swe_timber.py
+++ b/src/pyforestry/sweden/timber/swe_timber.py
@@ -1,21 +1,28 @@
+"""Timber class with Swedish volume model integrations."""
+
 from typing import Optional
+
 from pyforestry.base.timber import Timber
-from pyforestry.sweden.volume import (
-    BrandelVolume, 
-    carbonnier_1954_volume_larch,
-    andersson_1954_volume_small_trees_birch_height_above_4_m,
-    andersson_1954_volume_small_trees_pine,
-    andersson_1954_volume_small_trees_spruce,
-    andersson_1954_volume_small_trees_birch_under_diameter_5_cm,
-    Eriksson_1973_volume_aspen_Sweden,
-    Eriksson_1973_volume_lodgepole_pine_Sweden,
-    matern_1975_volume_sweden_beech,
-    matern_1975_volume_sweden_oak    
-)
+
 # Import SwedishSite and its region-specific namespace.
 from pyforestry.sweden.site import SwedishSite
+from pyforestry.sweden.volume import (
+    BrandelVolume,
+    Eriksson_1973_volume_aspen_Sweden,
+    Eriksson_1973_volume_lodgepole_pine_Sweden,
+    andersson_1954_volume_small_trees_birch_height_above_4_m,
+    andersson_1954_volume_small_trees_birch_under_diameter_5_cm,
+    andersson_1954_volume_small_trees_pine,
+    andersson_1954_volume_small_trees_spruce,
+    carbonnier_1954_volume_larch,
+    matern_1975_volume_sweden_beech,
+    matern_1975_volume_sweden_oak,
+)
+
 
 class SweTimber(Timber):
+    """Timber record with access to Swedish volume models."""
+
     def __init__(
         self,
         species: str,
@@ -27,8 +34,9 @@ class SweTimber(Timber):
         region: str = "southern",  # Default to "southern"; can be "northern"
         latitude: Optional[float] = None,
         # Optionally, supply a SwedishSite with additional region‐specific parameters.
-        swedish_site: Optional[SwedishSite] = None
+        swedish_site: Optional[SwedishSite] = None,
     ):
+        """Instantiate a timber record and infer missing fields."""
         self.species = species.lower()
         self.diameter_cm = diameter_cm
         self.height_m = height_m
@@ -40,9 +48,9 @@ class SweTimber(Timber):
 
         # If no latitude is provided, set one based on region.
         if latitude is None:
-            if self.region == 'northern':
+            if self.region == "northern":
                 self.latitude = 64
-            elif self.region == 'southern':
+            elif self.region == "southern":
                 self.latitude = 58
             else:
                 raise ValueError("Region must be 'northern' or 'southern'.")
@@ -55,17 +63,22 @@ class SweTimber(Timber):
         self.validate()
 
     def validate(self):
-        
+        """Verify that provided parameters are within valid ranges."""
         if self.height_m <= 0:
-            raise ValueError('Height must be larger than 0 m: {self.height_m}')
+            raise ValueError("Height must be larger than 0 m: {self.height_m}")
 
         if self.diameter_cm < 0:
             raise ValueError(f"Diameter must be larger or equal to 0 cm: {self.diameter_cm}")
-        if (self.crown_base_height_m is not None and self.height_m is not None and 
-            self.crown_base_height_m >= self.height_m):
-            raise ValueError(f'Crown base height ({self.crown_base_height_m} m) cannot be higher than tree height: {self.height_m} m')
+        if (
+            self.crown_base_height_m is not None
+            and self.height_m is not None
+            and self.crown_base_height_m >= self.height_m
+        ):
+            raise ValueError(
+                f"Crown base height ({self.crown_base_height_m} m) cannot be higher than tree height: {self.height_m} m"
+            )
         if self.stump_height_m < 0:
-            raise ValueError(f'Stump height must be larger or equal to 0 m: {self.stump_height_m}')
+            raise ValueError(f"Stump height must be larger or equal to 0 m: {self.stump_height_m}")
         if self.region not in ["northern", "southern"]:
             raise ValueError("Region must be 'northern' or 'southern'.")
         if self.species not in [
@@ -75,20 +88,23 @@ class SweTimber(Timber):
             "betula pendula",
             "betula pubescens",
         ]:
-            raise ValueError("Species must be one of: pinus sylvestris, picea abies, betula, betula pendula, betula pubescens.")
+            raise ValueError(
+                "Species must be one of: pinus sylvestris, picea abies, betula, betula pendula, betula pubescens."
+            )
 
     def getvolume(self):
+        """Return stem volume based on species and tree size."""
         # Return 0 if diameter is negative (as in C# code)
         if self.diameter_cm < 0:
             return 0
 
         # Define smallTree condition: a small tree is one with diameter < 4.5 cm or height < 7 m.
-        small_tree = (self.diameter_cm < 4.5 or self.height_m < 7)
+        small_tree = self.diameter_cm < 4.5 or self.height_m < 7
 
         sp = self.species  # species is already lower-case
 
         # Larch
-        if sp.startswith('larix'):
+        if sp.startswith("larix"):
             # In the C# code, for Larch we always call the Larch volume function.
             # Here we mimic that by using one volume function for larix.
             # We assume that if the diameter is large (>50 cm) we use the Brandel model,
@@ -96,154 +112,162 @@ class SweTimber(Timber):
             if self.diameter_cm > 50:
                 if self.swedish_site is not None:
                     vol = BrandelVolume.get_volume(
-                        species='pinus sylvestris',  # For larix, the model uses southern pine parameters.
+                        species="pinus sylvestris",  # For larix, the model uses southern pine parameters.
                         diameter_cm=self.diameter_cm,
                         height_m=self.height_m,
                         latitude=self.swedish_site.latitude,
                         altitude=self.swedish_site.altitude,
                         field_layer=self.swedish_site.field_layer.code,
-                        over_bark=self.over_bark
+                        over_bark=self.over_bark,
                     )
                 else:
                     vol = BrandelVolume.get_volume(
-                        species='pinus sylvestris',
+                        species="pinus sylvestris",
                         diameter_cm=self.diameter_cm,
                         height_m=self.height_m,
                         latitude=self.latitude,
-                        altitude=getattr(self, 'altitude', None),
-                        field_layer=getattr(self, 'field_layer', None),
-                        over_bark=self.over_bark
+                        altitude=getattr(self, "altitude", None),
+                        field_layer=getattr(self, "field_layer", None),
+                        over_bark=self.over_bark,
                     )
             else:
                 vol = carbonnier_1954_volume_larch(self.diameter_cm, self.height_m)
 
         # Pine (excluding larix sibirica)
-        elif sp == 'pinus sylvestris':
-                if small_tree:
-                    vol = andersson_1954_volume_small_trees_pine(self.diameter_cm, self.height_m)
+        elif sp == "pinus sylvestris":
+            if small_tree:
+                vol = andersson_1954_volume_small_trees_pine(self.diameter_cm, self.height_m)
+            else:
+                if self.swedish_site is not None:
+                    vol = BrandelVolume.get_volume(
+                        species="pinus sylvestris",
+                        diameter_cm=self.diameter_cm,
+                        height_m=self.height_m,
+                        latitude=self.swedish_site.latitude,
+                        altitude=self.swedish_site.altitude,
+                        field_layer=self.swedish_site.field_layer.code,
+                        over_bark=self.over_bark,
+                    )
                 else:
-                    if self.swedish_site is not None:
-                        vol = BrandelVolume.get_volume(
-                            species='pinus sylvestris',
-                            diameter_cm=self.diameter_cm,
-                            height_m=self.height_m,
-                            latitude=self.swedish_site.latitude,
-                            altitude=self.swedish_site.altitude,
-                            field_layer=self.swedish_site.field_layer.code,
-                            over_bark=self.over_bark
-                        )
-                    else:
-                        vol = BrandelVolume.get_volume(
-                            species='pinus sylvestris',
-                            diameter_cm=self.diameter_cm,
-                            height_m=self.height_m,
-                            latitude=self.latitude,
-                            altitude=getattr(self, 'altitude', None),
-                            field_layer=getattr(self, 'field_layer', None),
-                            over_bark=self.over_bark
-                        )
+                    vol = BrandelVolume.get_volume(
+                        species="pinus sylvestris",
+                        diameter_cm=self.diameter_cm,
+                        height_m=self.height_m,
+                        latitude=self.latitude,
+                        altitude=getattr(self, "altitude", None),
+                        field_layer=getattr(self, "field_layer", None),
+                        over_bark=self.over_bark,
+                    )
 
         # Spruce
-        elif sp == 'picea abies':
+        elif sp == "picea abies":
             if small_tree:
                 vol = andersson_1954_volume_small_trees_spruce(self.diameter_cm, self.height_m)
             else:
                 if self.swedish_site is not None:
                     vol = BrandelVolume.get_volume(
-                        species='picea abies',
+                        species="picea abies",
                         diameter_cm=self.diameter_cm,
                         height_m=self.height_m,
                         latitude=self.swedish_site.latitude,
                         altitude=self.swedish_site.altitude,
                         field_layer=self.swedish_site.field_layer.code,
-                        over_bark=self.over_bark
+                        over_bark=self.over_bark,
                     )
                 else:
                     vol = BrandelVolume.get_volume(
-                        species='picea abies',
+                        species="picea abies",
                         diameter_cm=self.diameter_cm,
                         height_m=self.height_m,
                         latitude=self.latitude,
-                        altitude=getattr(self, 'altitude', None),
-                        field_layer=getattr(self, 'field_layer', None),
-                        over_bark=self.over_bark
+                        altitude=getattr(self, "altitude", None),
+                        field_layer=getattr(self, "field_layer", None),
+                        over_bark=self.over_bark,
                     )
 
         # Birch
-        elif sp.startswith('betula'):
+        elif sp.startswith("betula"):
             if small_tree:
                 # Use different Andersson_1954 functions based on tree height.
                 if self.height_m > 4:
-                    vol = andersson_1954_volume_small_trees_birch_height_above_4_m(self.diameter_cm, self.height_m)
+                    vol = andersson_1954_volume_small_trees_birch_height_above_4_m(
+                        self.diameter_cm, self.height_m
+                    )
                 else:
-                    vol = andersson_1954_volume_small_trees_birch_under_diameter_5_cm(self.diameter_cm, self.height_m)
+                    vol = andersson_1954_volume_small_trees_birch_under_diameter_5_cm(
+                        self.diameter_cm, self.height_m
+                    )
             else:
                 if self.swedish_site is not None:
                     vol = BrandelVolume.get_volume(
-                        species='betula',
+                        species="betula",
                         diameter_cm=self.diameter_cm,
                         height_m=self.height_m,
                         latitude=self.swedish_site.latitude,
                         altitude=self.swedish_site.altitude,
                         field_layer=self.swedish_site.field_layer.code,
-                        over_bark=self.over_bark
+                        over_bark=self.over_bark,
                     )
                 else:
                     vol = BrandelVolume.get_volume(
-                        species='betula',
+                        species="betula",
                         diameter_cm=self.diameter_cm,
                         height_m=self.height_m,
                         latitude=self.latitude,
-                        altitude=getattr(self, 'altitude', None),
-                        field_layer=getattr(self, 'field_layer', None),
-                        over_bark=self.over_bark
+                        altitude=getattr(self, "altitude", None),
+                        field_layer=getattr(self, "field_layer", None),
+                        over_bark=self.over_bark,
                     )
 
         # Aspen (and related species)
-        elif sp in ['fraxinus excelsior', 'populus tremula'] or sp.startswith('alnus'):
+        elif sp in ["fraxinus excelsior", "populus tremula"] or sp.startswith("alnus"):
             vol = Eriksson_1973_volume_aspen_Sweden(self.diameter_cm, self.height_m)
 
         # Lodgepole pine (Contorta)
-        elif sp == 'pinus contorta':
+        elif sp == "pinus contorta":
             if small_tree:
                 vol = andersson_1954_volume_small_trees_pine(self.diameter_cm, self.height_m)
             else:
                 vol = Eriksson_1973_volume_lodgepole_pine_Sweden(self.diameter_cm, self.height_m)
 
         # Beech
-        elif sp in ['fagus sylvatica', 'carpinus betulus']:
+        elif sp in ["fagus sylvatica", "carpinus betulus"]:
             vol = matern_1975_volume_sweden_beech(self.diameter_cm, self.height_m)
 
         # Oak
-        elif sp.startswith('quercus'):
+        elif sp.startswith("quercus"):
             vol = matern_1975_volume_sweden_oak(self.diameter_cm, self.height_m)
 
         # Default fallback: use Birch model
         else:
             if small_tree:
                 if self.height_m > 4:
-                    vol = andersson_1954_volume_small_trees_birch_height_above_4_m(self.diameter_cm, self.height_m)
+                    vol = andersson_1954_volume_small_trees_birch_height_above_4_m(
+                        self.diameter_cm, self.height_m
+                    )
                 else:
-                    vol = andersson_1954_volume_small_trees_birch_under_diameter_5_cm(self.diameter_cm, self.height_m)
+                    vol = andersson_1954_volume_small_trees_birch_under_diameter_5_cm(
+                        self.diameter_cm, self.height_m
+                    )
             else:
                 if self.swedish_site is not None:
                     vol = BrandelVolume.get_volume(
-                        species='betula',
+                        species="betula",
                         diameter_cm=self.diameter_cm,
                         height_m=self.height_m,
                         latitude=self.swedish_site.latitude,
                         altitude=self.swedish_site.altitude,
                         field_layer=self.swedish_site.field_layer.code,
-                        over_bark=self.over_bark
+                        over_bark=self.over_bark,
                     )
                 else:
                     vol = BrandelVolume.get_volume(
-                        species='betula',
+                        species="betula",
                         diameter_cm=self.diameter_cm,
                         height_m=self.height_m,
                         latitude=self.latitude,
-                        altitude=getattr(self, 'altitude', None),
-                        field_layer=getattr(self, 'field_layer', None),
-                        over_bark=self.over_bark
+                        altitude=getattr(self, "altitude", None),
+                        field_layer=getattr(self, "field_layer", None),
+                        over_bark=self.over_bark,
                     )
         return vol

--- a/src/pyforestry/sweden/volume/__init__.py
+++ b/src/pyforestry/sweden/volume/__init__.py
@@ -1,3 +1,5 @@
+"""Lazy-loading interface for Swedish volume models."""
+
 # pyforestry/volume/__init__.py
 
 import importlib
@@ -5,64 +7,68 @@ import typing
 from typing import TYPE_CHECKING
 
 __all__ = [
-    'andersson_1954_volume_small_trees_birch_height_above_4_m',
-    'andersson_1954_volume_small_trees_pine',
-    'andersson_1954_volume_small_trees_spruce',
-    'andersson_1954_volume_small_trees_birch_under_diameter_5_cm',
-    'BrandelVolume',
-    'carbonnier_1954_volume_larch',
-    'johnsson_1953_volume_hybrid_aspen',
-    'matern_1975_volume_sweden_beech',
-    'matern_1975_volume_sweden_oak',
-    'NaslundVolume',
-    'NaslundFormFactor',
-    'Eriksson_1973_volume_aspen_Sweden',
-    'Eriksson_1973_volume_lodgepole_pine_Sweden',
+    "andersson_1954_volume_small_trees_birch_height_above_4_m",
+    "andersson_1954_volume_small_trees_pine",
+    "andersson_1954_volume_small_trees_spruce",
+    "andersson_1954_volume_small_trees_birch_under_diameter_5_cm",
+    "BrandelVolume",
+    "carbonnier_1954_volume_larch",
+    "johnsson_1953_volume_hybrid_aspen",
+    "matern_1975_volume_sweden_beech",
+    "matern_1975_volume_sweden_oak",
+    "NaslundVolume",
+    "NaslundFormFactor",
+    "Eriksson_1973_volume_aspen_Sweden",
+    "Eriksson_1973_volume_lodgepole_pine_Sweden",
 ]
 
 if TYPE_CHECKING:
     # imports only exist for the type checker—they are stripped at runtime
     from .andersson_1954 import (
         andersson_1954_volume_small_trees_birch_height_above_4_m,
+        andersson_1954_volume_small_trees_birch_under_diameter_5_cm,
         andersson_1954_volume_small_trees_pine,
         andersson_1954_volume_small_trees_spruce,
-        andersson_1954_volume_small_trees_birch_under_diameter_5_cm,
     )
     from .brandel_1990 import BrandelVolume
     from .carbonnier_1954 import carbonnier_1954_volume_larch
+    from .eriksson_1973 import (
+        Eriksson_1973_volume_aspen_Sweden,
+        Eriksson_1973_volume_lodgepole_pine_Sweden,
+    )
     from .johnsson_1953 import johnsson_1953_volume_hybrid_aspen
     from .matern_1975 import (
         matern_1975_volume_sweden_beech,
         matern_1975_volume_sweden_oak,
     )
-    from .naslund_1947 import NaslundVolume, NaslundFormFactor
-    from .eriksson_1973 import (
-        Eriksson_1973_volume_aspen_Sweden,
-        Eriksson_1973_volume_lodgepole_pine_Sweden,
-    )
+    from .naslund_1947 import NaslundFormFactor, NaslundVolume
 
 # Map of public name → submodule
 _name_to_module: typing.Dict[str, str] = {
-    'andersson_1954_volume_small_trees_birch_height_above_4_m': 'andersson_1954',
-    'andersson_1954_volume_small_trees_pine':               'andersson_1954',
-    'andersson_1954_volume_small_trees_spruce':             'andersson_1954',
-    'andersson_1954_volume_small_trees_birch_under_diameter_5_cm': 'andersson_1954',
-    'BrandelVolume':          'brandel_1990',
-    'carbonnier_1954_volume_larch':       'carbonnier_1954',
-    'johnsson_1953_volume_hybrid_aspen':  'johnsson_1953',
-    'matern_1975_volume_sweden_beech':    'matern_1975',
-    'matern_1975_volume_sweden_oak':      'matern_1975',
-    'NaslundVolume':            'naslund_1947',
-    'NaslundFormFactor':        'naslund_1947',
-    'Eriksson_1973_volume_aspen_Sweden':        'eriksson_1973',
-    'Eriksson_1973_volume_lodgepole_pine_Sweden':'eriksson_1973',
+    "andersson_1954_volume_small_trees_birch_height_above_4_m": "andersson_1954",
+    "andersson_1954_volume_small_trees_pine": "andersson_1954",
+    "andersson_1954_volume_small_trees_spruce": "andersson_1954",
+    "andersson_1954_volume_small_trees_birch_under_diameter_5_cm": "andersson_1954",
+    "BrandelVolume": "brandel_1990",
+    "carbonnier_1954_volume_larch": "carbonnier_1954",
+    "johnsson_1953_volume_hybrid_aspen": "johnsson_1953",
+    "matern_1975_volume_sweden_beech": "matern_1975",
+    "matern_1975_volume_sweden_oak": "matern_1975",
+    "NaslundVolume": "naslund_1947",
+    "NaslundFormFactor": "naslund_1947",
+    "Eriksson_1973_volume_aspen_Sweden": "eriksson_1973",
+    "Eriksson_1973_volume_lodgepole_pine_Sweden": "eriksson_1973",
 }
 
+
 def __getattr__(name: str):
+    """Load a volume model on demand."""
     if name in _name_to_module:
-        module = importlib.import_module(f'{__name__}.{_name_to_module[name]}')
+        module = importlib.import_module(f"{__name__}.{_name_to_module[name]}")
         return getattr(module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
 def __dir__():
+    """Return available public names for ``dir()``."""
     return sorted(__all__)


### PR DESCRIPTION
## Summary
- add module docstrings to helper and Swedish modules
- document SweTimber class and methods
- tidy helper utilities

## Testing
- `ruff check src/pyforestry/base/helpers/__init__.py src/pyforestry/base/helpers/primitives/__init__.py src/pyforestry/sweden/taper/__init__.py src/pyforestry/sweden/volume/__init__.py src/pyforestry/sweden/timber/__init__.py src/pyforestry/sweden/timber/swe_timber.py src/pyforestry/base/helpers/utils.py --fix`
- `black src/pyforestry/base/helpers/__init__.py src/pyforestry/base/helpers/primitives/__init__.py src/pyforestry/sweden/taper/__init__.py src/pyforestry/sweden/volume/__init__.py src/pyforestry/sweden/timber/__init__.py src/pyforestry/sweden/timber/swe_timber.py src/pyforestry/base/helpers/utils.py`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`

------
https://chatgpt.com/codex/tasks/task_e_687948cff10483298af26ea9f20106f3