### PR TITLE
Switch docs to pydata-sphinx-theme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ should be based on `dev` and pull requests should target `dev`. The `main` branc
    pip install -e .[dev]
    ```
 
-   This installs both runtime requirements and dev tools including **pytest**, **pytest-cov**, **docstr-coverage**, **coverage**, **black**, **ruff**, **sphinx**, **furo**, and **myst-parser**.
+   This installs both runtime requirements and dev tools including **pytest**, **pytest-cov**, **docstr-coverage**, **coverage**, **black**, **ruff**, **sphinx**, **pydata-sphinx-theme**, and **myst-parser**.
 
 ---
 
@@ -103,7 +103,7 @@ Releases merged into `main` must not decrease coverage.
 
 ## Documentation
 
-We use **Sphinx** (with **nbsphinx**, **myst-parser**, and the **furo** theme) to build documentation. Install docs dependencies (also listed in `requirements.txt`):
+We use **Sphinx** (with **nbsphinx**, **myst-parser**, and the **pydata-sphinx-theme** theme) to build documentation. Install docs dependencies (also listed in `requirements.txt`):
 
 ```bash
 pip install -r requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ sphinx>=6.0
 nbsphinx
 sphinx-rtd-theme>=1.2
 myst-parser>=0.18
-furo
+pydata-sphinx-theme>=0.16
 ipykernel
 pypandoc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,16 +51,15 @@ nbsphinx_execute = "always"
 nbsphinx_allow_errors = False
 
 # -- Options for HTML output -------------------------------------------------
-html_theme = "furo"  # or 'sphinx_rtd_theme', etc.
+html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 
 # Configure version switcher so users can toggle between dev/stable docs.
 DOCS_VERSION = os.environ.get("DOCS_VERSION", "dev")
 html_theme_options = {
-    "versioning": {
-        "current_version": DOCS_VERSION,
-        # ``versions.json`` lives at the root of the GitHub Pages site
-        "version_switcher": "https://silviculturalist.github.io/pyforestry/versions.json",
-        "docset_name": "pyforestry",
-    }
+    "navbar_end": ["theme-switcher", "version-switcher"],
+    "switcher": {
+        "version_match": DOCS_VERSION,
+        "json_url": "https://silviculturalist.github.io/pyforestry/versions.json",
+    },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
   "build",
   "twine",
   "sphinx",              # docs tool
-  "furo",                # a popular Sphinx theme
+  "pydata-sphinx-theme", # theme with version switcher support
   "myst-parser",         # if you want Markdown support
 ]
 


### PR DESCRIPTION
## Summary
- use `pydata_sphinx_theme` for docs
- install theme via docs requirements and dev extras
- update contributing guide

## Testing
- `ruff check docs/source/conf.py --fix`
- `black docs/source/conf.py`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`

------
https://chatgpt.com/codex/tasks/task_e_687b9de2155c8329a781f63ed36d605c