### PR TITLE
Fix version switcher json path

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,6 @@ html_theme_options = {
     "navbar_end": ["theme-switcher", "version-switcher"],
     "switcher": {
         "version_match": DOCS_VERSION,
-        "json_url": "https://silviculturalist.github.io/pyforestry/versions.json",
+        "json_url": "versions.json",
     },
 }


### PR DESCRIPTION
## Summary
- use local versions.json for Sphinx version switcher

## Testing
- `ruff check . --fix`
- `black .`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`


------
https://chatgpt.com/codex/tasks/task_e_687baa47ffec8329bce6c42cb37cbcc3