### PR TITLE
Fix docs warnings and version switcher

### DIFF
--- a/docs/source/api/pyforestry.base.helpers.primitives.rst
+++ b/docs/source/api/pyforestry.base.helpers.primitives.rst
@@ -5,6 +5,7 @@ pyforestry.base.helpers.primitives package
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Submodules
 ----------

--- a/docs/source/api/pyforestry.base.helpers.rst
+++ b/docs/source/api/pyforestry.base.helpers.rst
@@ -5,6 +5,7 @@ pyforestry.base.helpers package
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Subpackages
 -----------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,6 +53,7 @@ nbsphinx_allow_errors = False
 # -- Options for HTML output -------------------------------------------------
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+html_extra_path = ["../versions.json"]
 
 # Configure version switcher so users can toggle between dev/stable docs.
 DOCS_VERSION = os.environ.get("DOCS_VERSION", "dev")
@@ -60,6 +61,6 @@ html_theme_options = {
     "navbar_end": ["theme-switcher", "version-switcher"],
     "switcher": {
         "version_match": DOCS_VERSION,
-        "json_url": "versions.json",
+        "json_url": "../versions.json",
     },
 }


### PR DESCRIPTION
## Summary
- copy `versions.json` into the docs build and update the version switcher path
- avoid duplicate indices in helper docs
- verify documentation builds cleanly

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_687bbd6feed08329916ec4c01fcfb07d