### PR TITLE
Add base simulation framework

### DIFF
--- a/src/pyforestry/base/simulation/__init__.py
+++ b/src/pyforestry/base/simulation/__init__.py
@@ -1,0 +1,91 @@
+"""Interfaces for stand growth simulation modules."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Sequence
+
+from pyforestry.base.helpers import Stand, TreeName
+
+
+@dataclass
+class GrowthModule(ABC):
+    """Update existing trees to account for growth during a time step."""
+
+    supported_species: Sequence[TreeName] = field(default_factory=list)
+
+    def supports(self, species: TreeName) -> bool:
+        """Return ``True`` if ``species`` is handled by this module."""
+        return species in self.supported_species
+
+    @abstractmethod
+    def apply(self, stand: Stand) -> None:
+        """Modify ``stand`` in-place to reflect tree growth."""
+
+
+@dataclass
+class IngrowthModule(ABC):
+    """Add newly established trees to the stand."""
+
+    supported_species: Sequence[TreeName] = field(default_factory=list)
+
+    def supports(self, species: TreeName) -> bool:
+        """Return ``True`` if ``species`` is handled by this module."""
+        return species in self.supported_species
+
+    @abstractmethod
+    def apply(self, stand: Stand) -> None:
+        """Insert new trees into ``stand``."""
+
+
+@dataclass
+class MortalityModule(ABC):
+    """Remove trees that die between time steps."""
+
+    supported_species: Sequence[TreeName] = field(default_factory=list)
+
+    def supports(self, species: TreeName) -> bool:
+        """Return ``True`` if ``species`` is handled by this module."""
+        return species in self.supported_species
+
+    @abstractmethod
+    def apply(self, stand: Stand) -> None:
+        """Delete dead trees from ``stand``."""
+
+
+@dataclass
+class CalamityModule(ABC):
+    """Optional module simulating stochastic disturbances such as storms."""
+
+    supported_species: Sequence[TreeName] = field(default_factory=list)
+
+    def supports(self, species: TreeName) -> bool:
+        """Return ``True`` if ``species`` is handled by this module."""
+        return species in self.supported_species
+
+    @abstractmethod
+    def apply(self, stand: Stand) -> None:
+        """Apply calamity effects to ``stand``."""
+
+
+@dataclass
+class SimulationRuleset(ABC):
+    """Collection of modules defining a growth simulation."""
+
+    growth: GrowthModule
+    ingrowth: IngrowthModule
+    mortality: MortalityModule
+    calamity: CalamityModule | None = None
+
+    @abstractmethod
+    def grow(self, stand: Stand) -> None:
+        """Advance ``stand`` one step using the configured modules.
+
+        Implementations should execute the modules in the following order:
+
+        1. ``GrowthModule`` to update existing trees.
+        2. ``IngrowthModule`` to add new recruits.
+        3. ``MortalityModule`` to remove trees that died.
+        4. ``CalamityModule`` (if present) for disturbances.
+        """

--- a/tests/base/test_simulation.py
+++ b/tests/base/test_simulation.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+
+from pyforestry.base.helpers import Stand, TreeSpecies
+from pyforestry.base.simulation import (
+    CalamityModule,
+    GrowthModule,
+    IngrowthModule,
+    MortalityModule,
+    SimulationRuleset,
+)
+
+
+@dataclass
+class DummyGrowth(GrowthModule):
+    def apply(self, stand: Stand) -> None:
+        stand.attrs.setdefault("order", []).append("growth")
+
+
+@dataclass
+class DummyIngrowth(IngrowthModule):
+    def apply(self, stand: Stand) -> None:
+        stand.attrs.setdefault("order", []).append("ingrowth")
+
+
+@dataclass
+class DummyMortality(MortalityModule):
+    def apply(self, stand: Stand) -> None:
+        stand.attrs.setdefault("order", []).append("mortality")
+
+
+@dataclass
+class DummyCalamity(CalamityModule):
+    def apply(self, stand: Stand) -> None:
+        stand.attrs.setdefault("order", []).append("calamity")
+
+
+@dataclass
+class DummyRuleset(SimulationRuleset):
+    def grow(self, stand: Stand) -> None:
+        self.growth.apply(stand)
+        self.ingrowth.apply(stand)
+        self.mortality.apply(stand)
+        if self.calamity:
+            self.calamity.apply(stand)
+
+
+def test_supports_method() -> None:
+    sp = TreeSpecies.Sweden.picea_abies
+
+    class Module(DummyGrowth):
+        pass
+
+    m = Module(supported_species=[sp])
+    assert m.supports(sp)
+    assert not m.supports(TreeSpecies.Sweden.pinus_sylvestris)
+
+
+def test_ruleset_grow_order_without_calamity() -> None:
+    stand = Stand()
+    ruleset = DummyRuleset(DummyGrowth(), DummyIngrowth(), DummyMortality())
+    ruleset.grow(stand)
+    assert stand.attrs["order"] == ["growth", "ingrowth", "mortality"]
+
+
+def test_ruleset_grow_order_with_calamity() -> None:
+    stand = Stand()
+    ruleset = DummyRuleset(DummyGrowth(), DummyIngrowth(), DummyMortality(), DummyCalamity())
+    ruleset.grow(stand)
+    assert stand.attrs["order"] == [
+        "growth",
+        "ingrowth",
+        "mortality",
+        "calamity",
+    ]


### PR DESCRIPTION
## Summary
- create `base.simulation` package defining abstract simulation modules
- implement `SimulationRuleset` container
- provide tests covering module order and species support

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`
- `python scripts/check_changed_file_coverage.py $(git merge-base HEAD HEAD~1)`

------
https://chatgpt.com/codex/tasks/task_e_688b4b298e108329a348ab5474da8ef9