### PR TITLE
Implement Petersson 1999 biomass

### DIFF
--- a/src/pyforestry/sweden/biomass/__init__.py
+++ b/src/pyforestry/sweden/biomass/__init__.py
@@ -1,3 +1,5 @@
+"""Expose Swedish tree biomass models."""
+
 from .marklund_1988 import Marklund_1988
 from .petersson_1999 import Petersson1999
 from .petersson_stahl_2006 import PeterssonStahl2006

--- a/src/pyforestry/sweden/biomass/__init__.py
+++ b/src/pyforestry/sweden/biomass/__init__.py
@@ -1,4 +1,5 @@
 from .marklund_1988 import Marklund_1988
+from .petersson_1999 import Petersson1999
 from .petersson_stahl_2006 import PeterssonStahl2006
 
-__all__ = ["Marklund_1988", "PeterssonStahl2006"]
+__all__ = ["Marklund_1988", "PeterssonStahl2006", "Petersson1999"]

--- a/src/pyforestry/sweden/biomass/petersson_1999.py
+++ b/src/pyforestry/sweden/biomass/petersson_1999.py
@@ -30,7 +30,20 @@ class Petersson1999:
 
     @staticmethod
     def _validate_site_index(si: SiteIndexValue) -> TreeName:
-        """Validate that ``si`` references pine or spruce at age 100."""
+        """Validate a :class:`SiteIndexValue`.
+
+        Args:
+            si: Site index to validate.
+
+        Returns:
+            TreeName: Dominant species referenced by ``si``.
+
+        Raises:
+            TypeError: If ``si`` is not a :class:`SiteIndexValue`.
+            ValueError: If ``si`` does not reference pine or spruce at age
+                ``Age.TOTAL(100)`` or its function is not from
+                ``Hagglund_1970``.
+        """
 
         if not isinstance(si, SiteIndexValue):
             raise TypeError("SI must be a SiteIndexValue")
@@ -52,7 +65,19 @@ class Petersson1999:
         si: SiteIndexValue | float,
         dominant_species: TreeName | str | None,
     ) -> tuple[TreeName, float]:
-        """Return dominant species and numeric site index."""
+        """Resolve dominant species from ``SI`` and return its value.
+
+        Args:
+            si: Site index as an object or numeric value.
+            dominant_species: Species used when ``si`` is numeric.
+
+        Returns:
+            tuple[TreeName, float]: Dominant species and numeric site index.
+
+        Raises:
+            TypeError: If ``si`` is numeric and ``dominant_species`` is ``None``.
+            ValueError: If ``dominant_species`` is not pine or spruce.
+        """
 
         if isinstance(si, SiteIndexValue):
             dom = Petersson1999._validate_site_index(si)
@@ -88,7 +113,27 @@ class Petersson1999:
         altitude: float,
         dominant_species: TreeName | str | None = None,
     ) -> dict:
-        """Biomass components for a Norway spruce."""
+        """Biomass components for a Norway spruce.
+
+        Args:
+            diameter_cm: Diameter at breast height in centimetres.
+                If ``Diameter_cm`` is given, it must represent 1.3 m
+                measurement height and be taken over bark.
+            height_m: Tree height in metres.
+            age_at_breast_height: Age at breast height in years.
+            SI: Site index for the stand. When numeric, ``dominant_species``
+                must specify pine or spruce.
+            five_years_radial_increment_mm: Radial increment over five years
+                in millimetres.
+            peat: ``True`` if soil is peat (>30 cm deep).
+            latitude: Latitude in decimal degrees.
+            longitude: Longitude in decimal degrees.
+            altitude: Altitude in metres above sea level.
+            dominant_species: Species used for ``SI`` when ``SI`` is numeric.
+
+        Returns:
+            dict: Dry weight components in grams keyed by component name.
+        """
         dominant_species, SI = Petersson1999._get_dominant_species(SI, dominant_species)
         picea = dominant_species is TreeSpecies.Sweden.picea_abies
         pinus = dominant_species is TreeSpecies.Sweden.pinus_sylvestris
@@ -194,7 +239,27 @@ class Petersson1999:
         altitude: float,
         dominant_species: TreeName | str | None = None,
     ) -> dict:
-        """Biomass components for a Scots pine."""
+        """Biomass components for a Scots pine.
+
+        Args:
+            diameter_cm: Diameter at breast height in centimetres.
+                ``Diameter_cm`` must describe a 1.3 m, over-bark
+                measurement when used.
+            height_m: Tree height in metres.
+            age_at_breast_height: Age at breast height in years.
+            SI: Site index of the stand. When numeric, ``dominant_species``
+                must define pine or spruce.
+            five_years_radial_increment_mm: Radial increment over five years
+                in millimetres.
+            peat: ``True`` if soil is peat (>30 cm deep).
+            latitude: Latitude in decimal degrees.
+            longitude: Longitude in decimal degrees.
+            altitude: Altitude in metres above sea level.
+            dominant_species: Species used for ``SI`` when ``SI`` is numeric.
+
+        Returns:
+            dict: Dry weight components in grams keyed by component name.
+        """
         dominant_species, SI = Petersson1999._get_dominant_species(SI, dominant_species)
         picea = dominant_species is TreeSpecies.Sweden.picea_abies
         pinus = dominant_species is TreeSpecies.Sweden.pinus_sylvestris
@@ -305,7 +370,27 @@ class Petersson1999:
         altitude: float,
         dominant_species: TreeName | str | None = None,
     ) -> dict:
-        """Biomass components for birch (Betula spp.)."""
+        """Biomass components for birch (``Betula`` spp.).
+
+        Args:
+            diameter_cm: Diameter at breast height in centimetres. If a
+                ``Diameter_cm`` instance is supplied it must refer to a 1.3 m
+                over-bark measurement.
+            height_m: Tree height in metres.
+            age_at_breast_height: Age at breast height in years.
+            SI: Site index for the stand. Numeric values require
+                ``dominant_species``.
+            five_years_radial_increment_mm: Radial increment over five years in
+                millimetres.
+            peat: ``True`` if soil is peat (>30 cm deep).
+            latitude: Latitude in decimal degrees.
+            longitude: Longitude in decimal degrees.
+            altitude: Altitude in metres above sea level.
+            dominant_species: Species used for ``SI`` when ``SI`` is numeric.
+
+        Returns:
+            dict: Dry weight components in grams keyed by component name.
+        """
         dominant_species, SI = Petersson1999._get_dominant_species(SI, dominant_species)
         picea = dominant_species is TreeSpecies.Sweden.picea_abies
         pinus = dominant_species is TreeSpecies.Sweden.pinus_sylvestris
@@ -373,7 +458,30 @@ class Petersson1999:
         altitude: float,
         dominant_species: TreeName | str | None = None,
     ) -> dict:
-        """Dispatch biomass calculation based on species name."""
+        """Calculate biomass for a given species.
+
+        Args:
+            species: Tree species name or enum value.
+            diameter_cm: Diameter at breast height in centimetres.
+            height_m: Tree height in metres.
+            age_at_breast_height: Age at breast height in years.
+            SI: Site index for the stand. Numeric values require
+                ``dominant_species``.
+            five_years_radial_increment_mm: Radial increment over five years in
+                millimetres.
+            peat: ``True`` if soil is peat (>30 cm deep).
+            latitude: Latitude in decimal degrees.
+            longitude: Longitude in decimal degrees.
+            altitude: Altitude in metres above sea level.
+            dominant_species: Species used when ``SI`` is numeric.
+
+        Returns:
+            dict: Dry weight components in grams keyed by component name.
+
+        Raises:
+            TypeError: If ``species`` is not a valid tree species.
+            ValueError: If the species is not supported.
+        """
         if isinstance(species, str):
             species = parse_tree_species(species)
         if not isinstance(species, TreeName):

--- a/src/pyforestry/sweden/biomass/petersson_1999.py
+++ b/src/pyforestry/sweden/biomass/petersson_1999.py
@@ -1,0 +1,424 @@
+"""Above-ground biomass functions after Petersson (1999)."""
+
+from __future__ import annotations
+
+import warnings
+from inspect import getmodule
+
+import numpy as np
+
+from pyforestry.base.helpers import (
+    Age,
+    AgeMeasurement,
+    Diameter_cm,
+    SiteIndexValue,
+    TreeName,
+    TreeSpecies,
+    parse_tree_species,
+)
+
+
+class Petersson1999:
+    """Above-ground biomass models for common Swedish tree species.
+
+    The formulas implemented here originate from:
+
+    Petersson, H. (1999). *Biomassafunktioner för trädfaktorer av tall,
+    gran och björk i Sverige*. Report 59, Dept. of Forest Resources and
+    Geomatics, Swedish University of Agricultural Sciences.
+    """
+
+    @staticmethod
+    def _validate_site_index(si: SiteIndexValue) -> TreeName:
+        """Validate that ``si`` references pine or spruce at age 100."""
+
+        if not isinstance(si, SiteIndexValue):
+            raise TypeError("SI must be a SiteIndexValue")
+        if si.reference_age != Age.TOTAL(100):
+            raise ValueError("SI must have reference age Age.TOTAL(100)")
+        if si.species == {TreeSpecies.Sweden.picea_abies}:
+            dominant = TreeSpecies.Sweden.picea_abies
+        elif si.species == {TreeSpecies.Sweden.pinus_sylvestris}:
+            dominant = TreeSpecies.Sweden.pinus_sylvestris
+        else:
+            raise ValueError("SI must reference Picea abies or Pinus sylvestris")
+        mod = getmodule(si.fn)
+        if mod is None or not mod.__name__.endswith("hagglund_1970"):
+            raise ValueError("SI.fn must come from Hagglund_1970")
+        return dominant
+
+    @staticmethod
+    def _get_dominant_species(
+        si: SiteIndexValue | float,
+        dominant_species: TreeName | str | None,
+    ) -> tuple[TreeName, float]:
+        """Return dominant species and numeric site index."""
+
+        if isinstance(si, SiteIndexValue):
+            dom = Petersson1999._validate_site_index(si)
+            if dominant_species is not None:
+                warnings.warn(
+                    "dominant_species ignored when SI is SiteIndexValue",
+                    stacklevel=2,
+                )
+            return dom, float(si)
+
+        si_value = float(si)
+        if dominant_species is None:
+            raise TypeError("dominant_species required when SI is numeric")
+        if isinstance(dominant_species, str):
+            dominant_species = parse_tree_species(dominant_species)
+        if dominant_species not in {
+            TreeSpecies.Sweden.picea_abies,
+            TreeSpecies.Sweden.pinus_sylvestris,
+        }:
+            raise ValueError("dominant_species must be Picea abies or Pinus sylvestris")
+        return dominant_species, si_value
+
+    @staticmethod
+    def spruce(
+        diameter_cm: float | Diameter_cm,
+        height_m: float,
+        age_at_breast_height: float | AgeMeasurement,
+        SI: SiteIndexValue | float,
+        five_years_radial_increment_mm: float,
+        peat: bool,
+        latitude: float,
+        longitude: float,
+        altitude: float,
+        dominant_species: TreeName | str | None = None,
+    ) -> dict:
+        """Biomass components for a Norway spruce."""
+        dominant_species, SI = Petersson1999._get_dominant_species(SI, dominant_species)
+        picea = dominant_species is TreeSpecies.Sweden.picea_abies
+        pinus = dominant_species is TreeSpecies.Sweden.pinus_sylvestris
+
+        if isinstance(diameter_cm, Diameter_cm):
+            if diameter_cm.measurement_height_m != 1.3:
+                warnings.warn("diameter_cm measurement height not 1.3 m", stacklevel=2)
+            if not diameter_cm.over_bark:
+                raise ValueError("diameter_cm must be measured over bark")
+            diameter_cm = float(diameter_cm)
+        diameter_mm = diameter_cm * 10
+
+        if isinstance(age_at_breast_height, AgeMeasurement):
+            if age_at_breast_height.code != Age.DBH.value:
+                raise TypeError("age_at_breast_height must use Age.DBH measurement")
+            age_val = float(age_at_breast_height)
+        else:
+            age_val = float(age_at_breast_height)
+
+        increment_01mm = five_years_radial_increment_mm * 10
+        age_log = np.log(age_val)
+        inc_log = np.log(increment_01mm)
+        res = {}
+        res["stem_above_bark"] = np.exp(
+            -6.839310
+            + 3.578450 * np.log(diameter_mm + 25)
+            - 0.003042 * diameter_mm
+            + 0.093033 * inc_log
+            - 0.002763 * increment_01mm
+            + 0.111347 * age_log
+            + 0.012148 * float(SI) * picea
+            + 0.011586 * float(SI) * pinus
+            - 0.000020194 * latitude
+            + (0.17069**2) / 2
+        )
+        res["bark"] = np.exp(
+            -4.084706
+            + 2.397166 * np.log(diameter_mm + 10)
+            - 0.066053 * inc_log
+            + 0.151696 * age_log
+            + (0.22759**2) / 2
+        )
+        res["needles"] = np.exp(
+            -1.130238
+            + 1.485407 * np.log(diameter_mm)
+            + 0.514648 * inc_log
+            + 0.206901 * age_log
+            + (0.30852**2) / 2
+        )
+        res["living_branches"] = np.exp(
+            -0.718621
+            + 1.740810 * np.log(diameter_mm)
+            + 0.348379 * inc_log
+            + 0.180503 * age_log
+            + (0.28825**2) / 2
+        )
+        res["dead_branches"] = np.exp(
+            -1.763738
+            + 2.616200 * np.log(diameter_mm)
+            - 0.745459 * inc_log
+            - 0.359509 * age_log
+            + (0.79373**2) / 2
+        )
+        res["stump_root_gt5"] = np.exp(
+            -1.980469 + 2.339527 * np.log(diameter_mm) + 0.342786 * peat + (0.28283**2) / 2
+        )
+        res["above_stump"] = np.exp(
+            -0.437361
+            + 2.446692 * np.log(diameter_mm + 9)
+            + 0.065779 * inc_log
+            + 0.102290 * age_log
+            - 0.000021633 * latitude
+            + (0.15492**2) / 2
+        )
+        res["total"] = np.exp(
+            -0.614093
+            + 2.425997 * np.log(diameter_mm + 8)
+            + 0.081636 * inc_log
+            + 0.128027 * age_log
+            - 0.000015810 * latitude
+            + (0.15985**2) / 2
+        )
+        res["excluding_small_roots"] = np.exp(
+            -0.766217
+            + 2.491024 * np.log(diameter_mm + 8)
+            + 0.070526 * inc_log
+            + 0.113514 * age_log
+            - 0.000017876 * latitude
+            + (0.16274**2) / 2
+        )
+        return res
+
+    @staticmethod
+    def pine(
+        diameter_cm: float | Diameter_cm,
+        height_m: float,
+        age_at_breast_height: float | AgeMeasurement,
+        SI: SiteIndexValue | float,
+        five_years_radial_increment_mm: float,
+        peat: bool,
+        latitude: float,
+        longitude: float,
+        altitude: float,
+        dominant_species: TreeName | str | None = None,
+    ) -> dict:
+        """Biomass components for a Scots pine."""
+        dominant_species, SI = Petersson1999._get_dominant_species(SI, dominant_species)
+        picea = dominant_species is TreeSpecies.Sweden.picea_abies
+        pinus = dominant_species is TreeSpecies.Sweden.pinus_sylvestris
+
+        if isinstance(diameter_cm, Diameter_cm):
+            if diameter_cm.measurement_height_m != 1.3:
+                warnings.warn("diameter_cm measurement height not 1.3 m", stacklevel=2)
+            if not diameter_cm.over_bark:
+                raise ValueError("diameter_cm must be measured over bark")
+            diameter_cm = float(diameter_cm)
+        diameter_mm = diameter_cm * 10
+
+        if isinstance(age_at_breast_height, AgeMeasurement):
+            if age_at_breast_height.code != Age.DBH.value:
+                raise TypeError("age_at_breast_height must use Age.DBH measurement")
+            age_val = float(age_at_breast_height)
+        else:
+            age_val = float(age_at_breast_height)
+
+        increment_01mm = five_years_radial_increment_mm * 10
+        age_log = np.log(age_val)
+        inc_log = np.log(increment_01mm)
+        res = {}
+        res["stem_above_bark"] = np.exp(
+            -7.674621
+            + 3.155671 * np.log(diameter_mm + 25)
+            - 0.002197 * diameter_mm
+            + 0.084427 * inc_log
+            - 0.002665 * increment_01mm
+            + 0.253227 * age_log
+            + 0.028478 * float(SI) * picea
+            + 0.031435 * float(SI) * pinus
+            + 0.000008342 * latitude
+            + (0.17803**2) / 2
+        )
+        res["bark"] = np.exp(
+            -1.340149
+            + 2.209719 * np.log(diameter_mm + 13)
+            - 0.001986 * inc_log
+            - 0.000024146 * latitude
+            + (0.26942**2) / 2
+        )
+        res["needles"] = np.exp(
+            -2.597267
+            + 1.506121 * np.log(diameter_mm)
+            + 0.571366 * inc_log
+            + 0.208130 * age_log
+            + 0.000870 * altitude
+            + (0.35753**2) / 2
+        )
+        res["living_branches"] = np.exp(
+            -2.533220
+            + 1.989129 * np.log(diameter_mm)
+            + 0.387203 * inc_log
+            + 0.105215 * age_log
+            + (0.34938**2) / 2
+        )
+        res["dead_branches"] = np.exp(
+            1.596001
+            + 2.441173 * np.log(diameter_mm)
+            - 0.437497 * inc_log
+            - 0.711616 * age_log
+            - 0.001358 * altitude
+            - 0.000129 * longitude
+            + (0.76730**2) / 2
+        )
+        res["above_stump"] = np.exp(
+            -2.032666
+            + 2.413856 * np.log(diameter_mm + 6)
+            + 0.130304 * age_log
+            + 0.011834 * float(SI) * picea
+            + 0.013668 * float(SI) * pinus
+            + (0.15651**2) / 2
+        )
+        res["total"] = np.exp(
+            -1.507568
+            + 2.449121 * np.log(diameter_mm + 5)
+            + 0.104243 * age_log
+            - 0.000321 * altitude
+            + (0.16332**2) / 2
+        )
+        res["excluding_small_roots"] = np.exp(
+            -1.756201
+            + 2.483808 * np.log(diameter_mm + 5)
+            + 0.107190 * age_log
+            - 0.000325 * altitude
+            + (0.16086**2) / 2
+        )
+        res["stump_root_gt5"] = np.exp(
+            -1.980469
+            + 2.339527 * np.log(diameter_mm)
+            + 0.342786 * peat
+            - 0.224812
+            + (0.28283**2) / 2
+        )
+        return res
+
+    @staticmethod
+    def birch(
+        diameter_cm: float | Diameter_cm,
+        height_m: float,
+        age_at_breast_height: float | AgeMeasurement,
+        SI: SiteIndexValue | float,
+        five_years_radial_increment_mm: float,
+        peat: bool,
+        latitude: float,
+        longitude: float,
+        altitude: float,
+        dominant_species: TreeName | str | None = None,
+    ) -> dict:
+        """Biomass components for birch (Betula spp.)."""
+        dominant_species, SI = Petersson1999._get_dominant_species(SI, dominant_species)
+        picea = dominant_species is TreeSpecies.Sweden.picea_abies
+        pinus = dominant_species is TreeSpecies.Sweden.pinus_sylvestris
+
+        if isinstance(diameter_cm, Diameter_cm):
+            if diameter_cm.measurement_height_m != 1.3:
+                warnings.warn("diameter_cm measurement height not 1.3 m", stacklevel=2)
+            if not diameter_cm.over_bark:
+                raise ValueError("diameter_cm must be measured over bark")
+            diameter_cm = float(diameter_cm)
+        diameter_mm = diameter_cm * 10
+
+        if isinstance(age_at_breast_height, AgeMeasurement):
+            if age_at_breast_height.code != Age.DBH.value:
+                raise TypeError("age_at_breast_height must use Age.DBH measurement")
+            age_val = float(age_at_breast_height)
+        else:
+            age_val = float(age_at_breast_height)
+
+        increment_01mm = five_years_radial_increment_mm * 10
+        age_log = np.log(age_val)
+        inc_log = np.log(increment_01mm)
+        res = {}
+        res["stem_above_bark"] = np.exp(
+            -3.091932
+            + 2.479648 * np.log(diameter_mm + 7)
+            + 0.243747 * age_log
+            + 0.022185 * float(SI) * picea
+            + 0.022955 * float(SI) * pinus
+            + (0.19827**2) / 2
+        )
+        res["bark"] = np.exp(
+            -3.244490
+            + 2.525420 * np.log(diameter_mm + 18)
+            + 0.329744 * age_log
+            - 0.000030180 * latitude
+            + (0.25483**2) / 2
+        )
+        res["living_branches"] = np.exp(
+            -2.782537 + 2.276815 * np.log(diameter_mm) + 0.228528 * inc_log + (0.45153**2) / 2
+        )
+        res["dead_branches"] = np.exp(
+            -2.059091 + 1.657683 * np.log(diameter_mm) + (1.12848**2) / 2
+        )
+        res["above_stump"] = np.exp(
+            -0.423749
+            + 2.574575 * np.log(diameter_mm + 8)
+            + 0.090419 * age_log
+            - 0.000026862 * latitude
+            + (0.17071**2) / 2
+        )
+        return res
+
+    @staticmethod
+    def biomass(
+        species: TreeName | str,
+        diameter_cm: float | Diameter_cm,
+        height_m: float,
+        age_at_breast_height: float | AgeMeasurement,
+        SI: SiteIndexValue | float,
+        five_years_radial_increment_mm: float,
+        peat: bool,
+        latitude: float,
+        longitude: float,
+        altitude: float,
+        dominant_species: TreeName | str | None = None,
+    ) -> dict:
+        """Dispatch biomass calculation based on species name."""
+        if isinstance(species, str):
+            species = parse_tree_species(species)
+        if not isinstance(species, TreeName):
+            raise TypeError("species must be a TreeName or string")
+
+        if species is TreeSpecies.Sweden.picea_abies:
+            return Petersson1999.spruce(
+                diameter_cm,
+                height_m,
+                age_at_breast_height,
+                SI,
+                five_years_radial_increment_mm,
+                peat,
+                latitude,
+                longitude,
+                altitude,
+                dominant_species,
+            )
+        if species is TreeSpecies.Sweden.pinus_sylvestris:
+            return Petersson1999.pine(
+                diameter_cm,
+                height_m,
+                age_at_breast_height,
+                SI,
+                five_years_radial_increment_mm,
+                peat,
+                latitude,
+                longitude,
+                altitude,
+                dominant_species,
+            )
+        if species in {
+            TreeSpecies.Sweden.betula_pendula,
+            TreeSpecies.Sweden.betula_pubescens,
+        }:
+            return Petersson1999.birch(
+                diameter_cm,
+                height_m,
+                age_at_breast_height,
+                SI,
+                five_years_radial_increment_mm,
+                peat,
+                latitude,
+                longitude,
+                altitude,
+                dominant_species,
+            )
+        raise ValueError("Tree species not supported.")

--- a/tests/sweden/test_petersson_1999.py
+++ b/tests/sweden/test_petersson_1999.py
@@ -1,0 +1,376 @@
+import numpy as np
+import pytest
+
+from pyforestry.base.helpers import Age, Diameter_cm, SiteIndexValue, TreeSpecies
+from pyforestry.sweden.biomass.petersson_1999 import Petersson1999
+from pyforestry.sweden.siteindex import Hagglund_1970
+
+# Helper functions mirroring the equations for expected values
+
+
+def spruce_expected(**kwargs):
+    d = float(kwargs["diameter_cm"])
+    age = float(kwargs["age_at_breast_height"])
+    si = float(kwargs["SI"])
+    dom = kwargs["dominant_species"]
+    inc = kwargs["five_years_radial_increment_mm"]
+    peat = kwargs["peat"]
+    lat = kwargs["latitude"]
+    picea = dom is TreeSpecies.Sweden.picea_abies
+    pinus = dom is TreeSpecies.Sweden.pinus_sylvestris
+    mm = d * 10
+    inc01 = inc * 10
+    age_log = np.log(age)
+    inc_log = np.log(inc01)
+    return {
+        "stem_above_bark": np.exp(
+            -6.839310
+            + 3.578450 * np.log(mm + 25)
+            - 0.003042 * mm
+            + 0.093033 * inc_log
+            - 0.002763 * inc01
+            + 0.111347 * age_log
+            + 0.012148 * si * picea
+            + 0.011586 * si * pinus
+            - 0.000020194 * lat
+            + (0.17069**2) / 2
+        ),
+        "bark": np.exp(
+            -4.084706
+            + 2.397166 * np.log(mm + 10)
+            - 0.066053 * inc_log
+            + 0.151696 * age_log
+            + (0.22759**2) / 2
+        ),
+        "needles": np.exp(
+            -1.130238
+            + 1.485407 * np.log(mm)
+            + 0.514648 * inc_log
+            + 0.206901 * age_log
+            + (0.30852**2) / 2
+        ),
+        "living_branches": np.exp(
+            -0.718621
+            + 1.740810 * np.log(mm)
+            + 0.348379 * inc_log
+            + 0.180503 * age_log
+            + (0.28825**2) / 2
+        ),
+        "dead_branches": np.exp(
+            -1.763738
+            + 2.616200 * np.log(mm)
+            - 0.745459 * inc_log
+            - 0.359509 * age_log
+            + (0.79373**2) / 2
+        ),
+        "stump_root_gt5": np.exp(
+            -1.980469 + 2.339527 * np.log(mm) + 0.342786 * peat + (0.28283**2) / 2
+        ),
+        "above_stump": np.exp(
+            -0.437361
+            + 2.446692 * np.log(mm + 9)
+            + 0.065779 * inc_log
+            + 0.102290 * age_log
+            - 0.000021633 * lat
+            + (0.15492**2) / 2
+        ),
+        "total": np.exp(
+            -0.614093
+            + 2.425997 * np.log(mm + 8)
+            + 0.081636 * inc_log
+            + 0.128027 * age_log
+            - 0.000015810 * lat
+            + (0.15985**2) / 2
+        ),
+        "excluding_small_roots": np.exp(
+            -0.766217
+            + 2.491024 * np.log(mm + 8)
+            + 0.070526 * inc_log
+            + 0.113514 * age_log
+            - 0.000017876 * lat
+            + (0.16274**2) / 2
+        ),
+    }
+
+
+def pine_expected(**kwargs):
+    d = float(kwargs["diameter_cm"])
+    age = float(kwargs["age_at_breast_height"])
+    si = float(kwargs["SI"])
+    dom = kwargs["dominant_species"]
+    inc = kwargs["five_years_radial_increment_mm"]
+    peat = kwargs["peat"]
+    lat = kwargs["latitude"]
+    lon = kwargs["longitude"]
+    alt = kwargs["altitude"]
+    picea = dom is TreeSpecies.Sweden.picea_abies
+    pinus = dom is TreeSpecies.Sweden.pinus_sylvestris
+    mm = d * 10
+    inc01 = inc * 10
+    age_log = np.log(age)
+    inc_log = np.log(inc01)
+    return {
+        "stem_above_bark": np.exp(
+            -7.674621
+            + 3.155671 * np.log(mm + 25)
+            - 0.002197 * mm
+            + 0.084427 * inc_log
+            - 0.002665 * inc01
+            + 0.253227 * age_log
+            + 0.028478 * si * picea
+            + 0.031435 * si * pinus
+            + 0.000008342 * lat
+            + (0.17803**2) / 2
+        ),
+        "bark": np.exp(
+            -1.340149
+            + 2.209719 * np.log(mm + 13)
+            - 0.001986 * inc_log
+            - 0.000024146 * lat
+            + (0.26942**2) / 2
+        ),
+        "needles": np.exp(
+            -2.597267
+            + 1.506121 * np.log(mm)
+            + 0.571366 * inc_log
+            + 0.208130 * age_log
+            + 0.000870 * alt
+            + (0.35753**2) / 2
+        ),
+        "living_branches": np.exp(
+            -2.533220
+            + 1.989129 * np.log(mm)
+            + 0.387203 * inc_log
+            + 0.105215 * age_log
+            + (0.34938**2) / 2
+        ),
+        "dead_branches": np.exp(
+            1.596001
+            + 2.441173 * np.log(mm)
+            - 0.437497 * inc_log
+            - 0.711616 * age_log
+            - 0.001358 * alt
+            - 0.000129 * lon
+            + (0.76730**2) / 2
+        ),
+        "above_stump": np.exp(
+            -2.032666
+            + 2.413856 * np.log(mm + 6)
+            + 0.130304 * age_log
+            + 0.011834 * si * picea
+            + 0.013668 * si * pinus
+            + (0.15651**2) / 2
+        ),
+        "total": np.exp(
+            -1.507568
+            + 2.449121 * np.log(mm + 5)
+            + 0.104243 * age_log
+            - 0.000321 * alt
+            + (0.16332**2) / 2
+        ),
+        "excluding_small_roots": np.exp(
+            -1.756201
+            + 2.483808 * np.log(mm + 5)
+            + 0.107190 * age_log
+            - 0.000325 * alt
+            + (0.16086**2) / 2
+        ),
+        "stump_root_gt5": np.exp(
+            -1.980469
+            + 2.339527 * np.log(mm)
+            + 0.342786 * peat
+            - 0.224812 * True
+            + (0.28283**2) / 2
+        ),
+    }
+
+
+def birch_expected(**kwargs):
+    d = float(kwargs["diameter_cm"])
+    age = float(kwargs["age_at_breast_height"])
+    si = float(kwargs["SI"])
+    dom = kwargs["dominant_species"]
+    inc = kwargs["five_years_radial_increment_mm"]
+    lat = kwargs["latitude"]
+    picea = dom is TreeSpecies.Sweden.picea_abies
+    pinus = dom is TreeSpecies.Sweden.pinus_sylvestris
+    mm = d * 10
+    inc01 = inc * 10
+    age_log = np.log(age)
+    inc_log = np.log(inc01)
+    return {
+        "stem_above_bark": np.exp(
+            -3.091932
+            + 2.479648 * np.log(mm + 7)
+            + 0.243747 * age_log
+            + 0.022185 * si * picea
+            + 0.022955 * si * pinus
+            + (0.19827**2) / 2
+        ),
+        "bark": np.exp(
+            -3.244490
+            + 2.525420 * np.log(mm + 18)
+            + 0.329744 * age_log
+            - 0.000030180 * lat
+            + (0.25483**2) / 2
+        ),
+        "living_branches": np.exp(
+            -2.782537 + 2.276815 * np.log(mm) + 0.228528 * inc_log + (0.45153**2) / 2
+        ),
+        "dead_branches": np.exp(-2.059091 + 1.657683 * np.log(mm) + (1.12848**2) / 2),
+        "above_stump": np.exp(
+            -0.423749
+            + 2.574575 * np.log(mm + 8)
+            + 0.090419 * age_log
+            - 0.000026862 * lat
+            + (0.17071**2) / 2
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "species,expected_func",
+    [
+        (TreeSpecies.Sweden.picea_abies, spruce_expected),
+        (TreeSpecies.Sweden.pinus_sylvestris, pine_expected),
+        (TreeSpecies.Sweden.betula_pendula, birch_expected),
+    ],
+)
+def test_dispatch_matches_individual(species, expected_func):
+    args = {
+        "diameter_cm": Diameter_cm(20),
+        "height_m": 18,
+        "age_at_breast_height": Age.DBH(40),
+        "SI": SiteIndexValue(
+            25,
+            Age.TOTAL(100),
+            {TreeSpecies.Sweden.picea_abies},
+            Hagglund_1970.height_trajectory.picea_abies.northern_sweden,
+        ),
+        "five_years_radial_increment_mm": 4,
+        "peat": False,
+        "latitude": 60,
+        "longitude": 15,
+        "altitude": 200,
+    }
+    result = Petersson1999.biomass(species, **args)
+    expected = expected_func(dominant_species=TreeSpecies.Sweden.picea_abies, **args)
+    for key, val in expected.items():
+        assert result[key] == pytest.approx(val)
+
+
+def test_invalid_species():
+    with pytest.raises(ValueError):
+        Petersson1999.biomass(
+            "invalid",
+            Diameter_cm(20),
+            18,
+            Age.DBH(40),
+            SiteIndexValue(
+                25,
+                Age.TOTAL(100),
+                {TreeSpecies.Sweden.picea_abies},
+                Hagglund_1970.height_trajectory.picea_abies.northern_sweden,
+            ),
+            4,
+            False,
+            60,
+            15,
+            200,
+        )
+
+
+def test_site_index_validation():
+    with pytest.raises(ValueError):
+        Petersson1999.biomass(
+            TreeSpecies.Sweden.picea_abies,
+            Diameter_cm(20),
+            18,
+            Age.DBH(40),
+            SiteIndexValue(
+                25,
+                Age.TOTAL(50),
+                {TreeSpecies.Sweden.picea_abies},
+                Hagglund_1970.height_trajectory.picea_abies.northern_sweden,
+            ),
+            five_years_radial_increment_mm=4,
+            peat=False,
+            latitude=60,
+            longitude=15,
+            altitude=200,
+        )
+
+    with pytest.raises(ValueError):
+        Petersson1999.biomass(
+            TreeSpecies.Sweden.picea_abies,
+            Diameter_cm(20),
+            18,
+            Age.DBH(40),
+            SiteIndexValue(
+                25,
+                Age.TOTAL(100),
+                {TreeSpecies.Sweden.betula_pendula},
+                Hagglund_1970.height_trajectory.picea_abies.northern_sweden,
+            ),
+            five_years_radial_increment_mm=4,
+            peat=False,
+            latitude=60,
+            longitude=15,
+            altitude=200,
+        )
+
+    with pytest.raises(ValueError):
+        Petersson1999.biomass(
+            TreeSpecies.Sweden.picea_abies,
+            Diameter_cm(20),
+            18,
+            Age.DBH(40),
+            SiteIndexValue(
+                25,
+                Age.TOTAL(100),
+                {TreeSpecies.Sweden.picea_abies},
+                lambda: None,
+            ),
+            five_years_radial_increment_mm=4,
+            peat=False,
+            latitude=60,
+            longitude=15,
+            altitude=200,
+        )
+
+
+def test_numeric_si_with_string_species():
+    args = {
+        "diameter_cm": Diameter_cm(20),
+        "height_m": 18,
+        "age_at_breast_height": Age.DBH(40),
+        "SI": 25.0,
+        "dominant_species": "Picea abies",
+        "five_years_radial_increment_mm": 4,
+        "peat": False,
+        "latitude": 60,
+        "longitude": 15,
+        "altitude": 200,
+    }
+    result = Petersson1999.biomass(TreeSpecies.Sweden.picea_abies, **args)
+    args_for_expected = args.copy()
+    args_for_expected["dominant_species"] = TreeSpecies.Sweden.picea_abies
+    expected = spruce_expected(**args_for_expected)
+    for key, val in expected.items():
+        assert result[key] == pytest.approx(val)
+
+
+def test_numeric_si_requires_dominant_species():
+    with pytest.raises(TypeError):
+        Petersson1999.biomass(
+            TreeSpecies.Sweden.picea_abies,
+            Diameter_cm(20),
+            18,
+            Age.DBH(40),
+            25.0,
+            five_years_radial_increment_mm=4,
+            peat=False,
+            latitude=60,
+            longitude=15,
+            altitude=200,
+        )


### PR DESCRIPTION
## Summary
- add site-index validation and dominant species detection to Petersson 1999
- support numeric site index with explicit species
- update biomass tests for new validation logic

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`
- `python scripts/check_changed_file_coverage.py $(git merge-base HEAD origin/dev)` *(fails: Not a valid object name)*

------
https://chatgpt.com/codex/tasks/task_e_688b4d5c856883298cb4fe119d0b4e37