### PR TITLE
Add basal-area weighted diameter stand metric

### DIFF
--- a/src/pyforestry/base/helpers/primitives/__init__.py
+++ b/src/pyforestry/base/helpers/primitives/__init__.py
@@ -2,6 +2,7 @@
 
 from .age import Age, AgeMeasurement
 from .area_aggregates import StandBasalArea, StandVolume, Stems
+from .bawad import BasalAreaWeightedDiameter
 from .cartesian_position import Position
 from .diameter_cm import Diameter_cm
 from .qmd import QuadraticMeanDiameter
@@ -18,6 +19,7 @@ __all__ = [
     "Stems",
     "Position",
     "Diameter_cm",
+    "BasalAreaWeightedDiameter",
     "QuadraticMeanDiameter",
     "SiteBase",
     "SiteIndexValue",

--- a/src/pyforestry/base/helpers/primitives/bawad.py
+++ b/src/pyforestry/base/helpers/primitives/bawad.py
@@ -1,0 +1,47 @@
+"""Class representing the basal-area weighted mean diameter (BAWAD).
+
+BAWAD is defined as the ratio of the sum of cubed diameters to the sum
+of squared diameters for a collection of trees::
+
+    BAWAD = sum(D^3) / sum(D^2)
+
+It is expressed in centimetres and carries an optional precision
+attribute.
+"""
+
+
+class BasalAreaWeightedDiameter(float):
+    """A diameter measurement weighted by basal area.
+
+        This subclass of :class:`float` stores the basal-area weighted mean
+    diameter in centimetres along with an associated measurement
+    precision.
+
+        Parameters
+        ----------
+        value:
+            The computed BAWAD value in centimetres. Must be non-negative.
+        precision:
+            Optional precision (standard error) of the measurement in
+            centimetres.
+    """
+
+    __slots__ = "precision"
+
+    def __new__(cls, value: float, precision: float = 0.0):
+        if value < 0:
+            raise ValueError("BasalAreaWeightedDiameter must be non-negative.")
+        obj = float.__new__(cls, value)
+        obj.precision = precision
+        return obj
+
+    @property
+    def value(self) -> float:
+        """Return the raw BAWAD value in centimetres."""
+        return float(self)
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        """Return a readable representation of the diameter."""
+        return (
+            f"BasalAreaWeightedDiameter({float(self):.2f} cm, precision={self.precision:.2f} cm)"
+        )

--- a/tests/base/test_stand_plot.py
+++ b/tests/base/test_stand_plot.py
@@ -98,16 +98,23 @@ def test_stand_metric_calculations():
     # Force compute:
     val_stems_total = float(st.Stems)
     val_ba_total = float(st.BasalArea)
+    val_bawad_total = float(st.BAWAD)
 
     # We won't assert the exact numbers too strictly, but we can check they're >0
     assert val_stems_total > 0
     assert val_ba_total > 0
+    assert val_bawad_total > 0
 
     # We can also specifically request species-level results:
     ba_picea = st.BasalArea(sp_picea)
     ba_pinus = st.BasalArea("pinus sylvestris")
+    bawad_picea = st.BAWAD(sp_picea)
+    bawad_pinus = st.BAWAD("pinus sylvestris")
     assert ba_picea.value > 0
     assert ba_pinus.value > 0
+    assert math.isclose(bawad_picea.value, 23.78787878, rel_tol=1e-6)
+    assert math.isclose(bawad_pinus.value, 33.65671642, rel_tol=1e-6)
+    assert math.isclose(val_bawad_total, 30.4, rel_tol=1e-6)
 
 
 def test_stand_metric_accessor_keyerror():
@@ -115,6 +122,16 @@ def test_stand_metric_accessor_keyerror():
     st = Stand(plots=[])
     with pytest.raises(KeyError):
         st.BasalArea("picea abies")
+
+
+def test_bawad_unavailable_with_angle_count():
+    """BAWAD should raise KeyError when only angle-count data are present."""
+    sp = parse_tree_species("picea abies")
+    ac = AngleCount(ba_factor=2.0, value=[4], species=[sp], point_id="P1")
+    plot = CircularPlot(id=1, radius_m=5, AngleCount=[ac])
+    st = Stand(plots=[plot])
+    with pytest.raises(KeyError):
+        float(st.BAWAD)
 
 
 def test_CircularPlot_area_ha_property():


### PR DESCRIPTION
## Summary
- introduce `BasalAreaWeightedDiameter` primitive and expose via `Stand.BAWAD`
- compute basal-area weighted mean diameter (BAWAD) from per-tree diameters
- verify BAWAD calculations and angle-count handling with new tests

## Testing
- `ruff check .`
- `ruff format .`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`
- `python scripts/check_changed_file_coverage.py $(git merge-base HEAD origin/dev)`

------
https://chatgpt.com/codex/tasks/task_e_68a86d7daf0c8329b8ccaf95a9268832