### PR TITLE
docs: fix sponsor image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ environment and submitting pull requests.
 ## Sponsors
 This project has been sponsored by [Digital Impact North](https://www.digitalimpactnorth.se).
 
-![Digital Impact North](docs/source/_static/digital-impact-north.png)
+![Digital Impact North](docs/images/DIN_logotyp_primar_gron.png)
 
 ## License
 `pyforestry` is distributed under the terms of the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- fix broken sponsor logo link in README

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50`
- `python scripts/check_changed_file_coverage.py $(git merge-base HEAD origin/dev)` *(fails: Not a valid object name origin/dev)*

------
https://chatgpt.com/codex/tasks/task_e_68a8746556148329b8a189f3fa5afa37