### PR TITLE
Fix Nasberg 1985 decimetre calculation

### DIFF
--- a/src/pyforestry/base/timber_bucking/nasberg_1985.py
+++ b/src/pyforestry/base/timber_bucking/nasberg_1985.py
@@ -125,7 +125,7 @@ class Nasberg_1985_BranchBound:
         # ------------ discretise (vector) --------------------------------
 
         NMAX = 400
-        total_dm = min(int((HTOP - HSTUB * 10)), NMAX)
+        total_dm = min(int((HTOP - HSTUB) * 10), NMAX)
         if total_dm <= 0:
             return BuckingResult(0, 1, 1, 1, 1, 0, [0] * 7, [0] * 7, 0, 0)
 


### PR DESCRIPTION
## Summary
- apply the correct order of operations when converting the available height range into decimetres in the Nasberg 1985 bucking algorithm

## Testing
- ruff check . --fix
- ruff format .
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50

------
https://chatgpt.com/codex/tasks/task_e_68e915a82b4c832990296990a366ea29