### PR TITLE
Add simulation checkpointing utilities and tests

### DIFF
--- a/src/pyforestry/simulation/__init__.py
+++ b/src/pyforestry/simulation/__init__.py
@@ -1,0 +1,31 @@
+"""Simulation utilities for managing model state.
+
+The :mod:`pyforestry.simulation` package collects helpers that are useful when
+running growth or yield simulations.  Modules here focus on orthogonal
+concerns such as checkpointing model state and preparing inputs for external
+engines rather than prescribing a particular simulator implementation.
+"""
+
+from .checkpointing import (
+    TreeCheckpoint,
+    restore_plot,
+    restore_stand,
+    restore_tree,
+    restore_trees,
+    serialize_tree,
+    snapshot_plot,
+    snapshot_stand,
+    snapshot_trees,
+)
+
+__all__ = [
+    "TreeCheckpoint",
+    "restore_plot",
+    "restore_stand",
+    "restore_tree",
+    "restore_trees",
+    "serialize_tree",
+    "snapshot_plot",
+    "snapshot_stand",
+    "snapshot_trees",
+]

--- a/src/pyforestry/simulation/checkpointing.py
+++ b/src/pyforestry/simulation/checkpointing.py
@@ -1,0 +1,338 @@
+"""Serialization utilities for checkpointing tree- and stand-level state.
+
+The helpers in this module translate :class:`~pyforestry.base.helpers.tree.Tree`
+objects into plain dictionaries that can be stored using common persistence
+formats such as JSON, CSV, Parquet, or database rows.  Every value emitted by
+:func:`serialize_tree` is JSON serialisable which means snapshots can be
+written directly to object storage, parquet writers, or column stores without
+custom encoders.  The inverse operation, :func:`restore_tree`, rebuilds
+:class:`Tree` instances from those dictionaries.
+
+Batch helpers (``snapshot_*``/``restore_*``) provide convenient utilities for
+entire collections.  ``snapshot_plot`` and ``snapshot_stand`` return lists of
+:class:`TreeCheckpoint` objects that can be fed to arrow/parquet writers or
+further transformed before storage, while ``restore_plot`` and
+``restore_stand`` hydrate :class:`Tree` objects from either ``TreeCheckpoint``
+instances or raw dictionaries as loaded from JSON files.
+
+The emitted dictionaries use the following field structure:
+
+``position``
+    ``{"x": float, "y": float, "z": float | None, "crs": str | None}``.
+    ``crs`` uses :func:`pyproj.CRS.to_string` so it is readily reversible.
+``species``
+    ``{"code": str | None, "full_name": str | None}``.  ``code`` corresponds
+    to entries in :data:`pyforestry.base.helpers.tree_species.GLOBAL_TREE_SPECIES`
+    and is preferred for lookups, while ``full_name`` is used as a fallback via
+    :func:`pyforestry.base.helpers.tree_species.parse_tree_species`.
+``age``
+    ``{"kind": "measurement"|"enum"|"numeric", "value": float | None, "code": int | None}``.
+``diameter_cm``
+    ``{"kind": "diameter_cm"|"numeric", "value": float, "over_bark": bool | None,
+    "measurement_height_m": float | None}``.
+``height_m``
+    Raw numeric height (metres) or ``None``.
+``weight_n``
+    Stem expansion factor (number of stems represented) or ``None``.
+``uid``
+    Optional identifier preserved without interpretation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping, Optional, Sequence, Union
+
+from pyproj import CRS
+
+from pyforestry.base.helpers.plot import CircularPlot
+from pyforestry.base.helpers.primitives.age import Age, AgeMeasurement
+from pyforestry.base.helpers.primitives.cartesian_position import Position
+from pyforestry.base.helpers.primitives.diameter_cm import Diameter_cm
+from pyforestry.base.helpers.stand import Stand
+from pyforestry.base.helpers.tree import Tree
+from pyforestry.base.helpers.tree_species import (
+    GLOBAL_TREE_SPECIES,
+    TreeName,
+    parse_tree_species,
+)
+
+
+@dataclass(slots=True)
+class TreeCheckpoint:
+    """Lightweight, serialisable representation of a :class:`Tree`.
+
+    Instances of this dataclass carry only JSON-compatible values so they can
+    be stored directly or converted to Python dictionaries via
+    :func:`dataclasses.asdict`.  Use :func:`serialize_tree` and
+    :func:`restore_tree` for the high-level conversion functions.
+    """
+
+    position: Optional[Mapping[str, Any]] = None
+    species: Optional[Mapping[str, Optional[str]]] = None
+    age: Optional[Mapping[str, Optional[Union[int, float, str]]]] = None
+    diameter_cm: Optional[Mapping[str, Optional[Union[bool, float, str]]]] = None
+    height_m: Optional[float] = None
+    weight_n: Optional[float] = 1.0
+    uid: Optional[Union[int, str]] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deep copy of the checkpoint suitable for serialisation."""
+
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "TreeCheckpoint":
+        """Hydrate a checkpoint from a mapping of primitive values."""
+
+        return cls(
+            position=data.get("position"),
+            species=data.get("species"),
+            age=data.get("age"),
+            diameter_cm=data.get("diameter_cm"),
+            height_m=data.get("height_m"),
+            weight_n=data.get("weight_n"),
+            uid=data.get("uid"),
+        )
+
+
+def serialize_tree(tree: Tree) -> dict[str, Any]:
+    """Convert a :class:`Tree` instance into a serialisable dictionary."""
+
+    checkpoint = TreeCheckpoint(
+        position=_serialize_position(tree.position),
+        species=_serialize_species(tree.species),
+        age=_serialize_age(tree.age),
+        diameter_cm=_serialize_diameter(tree.diameter_cm),
+        height_m=tree.height_m,
+        weight_n=tree.weight_n,
+        uid=tree.uid,
+    )
+    return checkpoint.to_dict()
+
+
+def restore_tree(data: Mapping[str, Any] | TreeCheckpoint) -> Tree:
+    """Rebuild a :class:`Tree` from a checkpoint dictionary or dataclass."""
+
+    checkpoint = data if isinstance(data, TreeCheckpoint) else TreeCheckpoint.from_dict(data)
+
+    position = _restore_position(checkpoint.position)
+    species = _restore_species(checkpoint.species)
+    age = _restore_age(checkpoint.age)
+    diameter = _restore_diameter(checkpoint.diameter_cm)
+
+    return Tree(
+        position=position,
+        species=species,
+        age=age,
+        diameter_cm=diameter,
+        height_m=checkpoint.height_m,
+        weight_n=checkpoint.weight_n,
+        uid=checkpoint.uid,
+    )
+
+
+def snapshot_trees(trees: Iterable[Tree]) -> list[TreeCheckpoint]:
+    """Snapshot an iterable of :class:`Tree` instances."""
+
+    return [
+        TreeCheckpoint(
+            position=_serialize_position(tree.position),
+            species=_serialize_species(tree.species),
+            age=_serialize_age(tree.age),
+            diameter_cm=_serialize_diameter(tree.diameter_cm),
+            height_m=tree.height_m,
+            weight_n=tree.weight_n,
+            uid=tree.uid,
+        )
+        for tree in trees
+    ]
+
+
+def snapshot_plot(plot: CircularPlot) -> list[TreeCheckpoint]:
+    """Return checkpoints for every tree stored on ``plot``."""
+
+    return snapshot_trees(plot.trees)
+
+
+def snapshot_stand(stand: Stand) -> list[TreeCheckpoint]:
+    """Return checkpoints for all trees across every plot in ``stand``."""
+
+    plots: Sequence[CircularPlot]
+    iterator = getattr(stand, "__iter__", None)
+    if callable(iterator):
+        plots = list(iterator())  # type: ignore[arg-type]
+    else:
+        plots = stand.plots
+
+    snapshots: list[TreeCheckpoint] = []
+    for plot in plots:
+        snapshots.extend(snapshot_plot(plot))
+    return snapshots
+
+
+def restore_trees(
+    checkpoints: Iterable[Mapping[str, Any] | TreeCheckpoint],
+) -> list[Tree]:
+    """Restore a list of :class:`Tree` objects from ``checkpoints``."""
+
+    return [restore_tree(checkpoint) for checkpoint in checkpoints]
+
+
+def restore_plot(
+    checkpoints: Iterable[Mapping[str, Any] | TreeCheckpoint],
+) -> list[Tree]:
+    """Restore the tree list for a plot from ``checkpoints``."""
+
+    return restore_trees(checkpoints)
+
+
+def restore_stand(
+    checkpoints: Iterable[Mapping[str, Any] | TreeCheckpoint],
+) -> list[Tree]:
+    """Restore a flattened list of trees for an entire stand."""
+
+    return restore_trees(checkpoints)
+
+
+def _serialize_position(position: Optional[Position]) -> Optional[dict[str, Any]]:
+    if position is None:
+        return None
+
+    crs = position.crs.to_string() if getattr(position, "crs", None) else None
+    return {
+        "x": position.X,
+        "y": position.Y,
+        "z": position.Z,
+        "crs": crs,
+    }
+
+
+def _restore_position(data: Optional[Mapping[str, Any]]) -> Optional[Position]:
+    if not data:
+        return None
+
+    crs_value = data.get("crs")
+    crs = CRS.from_user_input(crs_value) if crs_value else None
+    return Position(
+        X=data.get("x", 0.0),
+        Y=data.get("y", 0.0),
+        Z=data.get("z"),
+        crs=crs,
+    )
+
+
+def _serialize_species(species: Optional[Union[TreeName, str]]) -> Optional[dict[str, Any]]:
+    if species is None:
+        return None
+
+    if isinstance(species, TreeName):
+        return {"code": species.code, "full_name": species.full_name}
+    return {"code": None, "full_name": str(species)}
+
+
+def _restore_species(data: Optional[Mapping[str, Any]]) -> Optional[TreeName]:
+    if not data:
+        return None
+
+    code = data.get("code")
+    if code:
+        for candidate in GLOBAL_TREE_SPECIES:
+            if candidate.code == code:
+                return candidate
+
+    full_name = data.get("full_name")
+    if full_name:
+        try:
+            return parse_tree_species(full_name)
+        except ValueError:
+            return None
+    return None
+
+
+def _serialize_age(age: Optional[Any]) -> Optional[dict[str, Any]]:
+    if age is None:
+        return None
+
+    if isinstance(age, AgeMeasurement):
+        return {"kind": "measurement", "value": float(age), "code": age.code}
+    if isinstance(age, Age):
+        return {"kind": "enum", "value": None, "code": age.value}
+    return {"kind": "numeric", "value": float(age), "code": None}
+
+
+def _restore_age(data: Optional[Mapping[str, Any]]) -> Optional[Any]:
+    if not data:
+        return None
+
+    kind = data.get("kind")
+    code = data.get("code")
+    value = data.get("value")
+
+    if kind == "measurement":
+        if value is None or code is None:
+            return None
+        return AgeMeasurement(float(value), int(code))
+    if kind == "enum":
+        if code is None:
+            return None
+        try:
+            return Age(int(code))
+        except ValueError:
+            return None
+    if kind == "numeric":
+        if value is None:
+            return None
+        return float(value)
+
+    # Fallback for legacy/unknown structures
+    if value is not None and code is not None:
+        try:
+            return AgeMeasurement(float(value), int(code))
+        except (TypeError, ValueError):
+            pass
+    if value is not None:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _serialize_diameter(diameter: Optional[Union[Diameter_cm, float]]) -> Optional[dict[str, Any]]:
+    if diameter is None:
+        return None
+
+    if isinstance(diameter, Diameter_cm):
+        return {
+            "kind": "diameter_cm",
+            "value": float(diameter),
+            "over_bark": getattr(diameter, "over_bark", True),
+            "measurement_height_m": getattr(diameter, "measurement_height_m", 1.3),
+        }
+    return {"kind": "numeric", "value": float(diameter)}
+
+
+def _restore_diameter(data: Optional[Mapping[str, Any]]) -> Optional[Union[Diameter_cm, float]]:
+    if not data:
+        return None
+
+    kind = data.get("kind")
+    value = data.get("value")
+
+    if value is None:
+        return None
+
+    if kind == "diameter_cm" or "over_bark" in data or "measurement_height_m" in data:
+        over_bark = data.get("over_bark", True)
+        measurement_height_m = data.get("measurement_height_m", 1.3)
+        measurement_height = measurement_height_m if measurement_height_m is not None else 1.3
+        return Diameter_cm(
+            float(value),
+            over_bark=bool(over_bark),
+            measurement_height_m=float(measurement_height),
+        )
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/simulation/test_checkpointing.py
+++ b/tests/simulation/test_checkpointing.py
@@ -1,0 +1,191 @@
+from collections import Counter
+
+import pytest
+from pyproj import CRS
+
+from pyforestry.base.helpers.plot import CircularPlot
+from pyforestry.base.helpers.primitives.age import Age, AgeMeasurement
+from pyforestry.base.helpers.primitives.cartesian_position import Position
+from pyforestry.base.helpers.primitives.diameter_cm import Diameter_cm
+from pyforestry.base.helpers.tree import Tree
+from pyforestry.base.helpers.tree_species import BETULA_PENDULA, PINUS_SYLVESTRIS
+from pyforestry.simulation.checkpointing import (
+    restore_plot,
+    restore_stand,
+    restore_tree,
+    serialize_tree,
+    snapshot_plot,
+    snapshot_stand,
+)
+
+
+def test_serialize_restore_tree_round_trip():
+    tree = Tree(
+        position=Position(10.0, 20.0, 3.0, crs=CRS.from_epsg(3006)),
+        species=PINUS_SYLVESTRIS,
+        age=Age.TOTAL(80),
+        diameter_cm=Diameter_cm(25.3, over_bark=False, measurement_height_m=0.65),
+        height_m=22.4,
+        weight_n=3.0,
+        uid=1234,
+    )
+
+    payload = serialize_tree(tree)
+    restored = restore_tree(payload)
+
+    assert restored.uid == tree.uid
+    assert restored.weight_n == pytest.approx(tree.weight_n)
+    assert restored.height_m == pytest.approx(tree.height_m)
+    assert isinstance(restored.diameter_cm, Diameter_cm)
+    assert float(restored.diameter_cm) == pytest.approx(float(tree.diameter_cm))
+    assert restored.diameter_cm.over_bark is False
+    assert restored.diameter_cm.measurement_height_m == pytest.approx(0.65)
+    assert restored.species == tree.species
+    assert isinstance(restored.position, Position)
+    assert restored.position.X == pytest.approx(tree.position.X)
+    assert restored.position.Y == pytest.approx(tree.position.Y)
+    assert restored.position.Z == pytest.approx(tree.position.Z)
+    assert restored.position.crs.to_epsg() == tree.position.crs.to_epsg()
+    assert restored.age == tree.age
+
+
+def test_snapshot_restore_stand_mixed_species():
+    plot_a = CircularPlot(
+        id="a",
+        radius_m=10.0,
+        trees=[
+            Tree(
+                position=Position(1.0, 2.0),
+                species=PINUS_SYLVESTRIS,
+                age=Age.DBH,
+                diameter_cm=Diameter_cm(18.0),
+                height_m=15.2,
+                weight_n=2.0,
+                uid="a1",
+            ),
+            Tree(
+                position=Position(2.5, 4.0),
+                species=BETULA_PENDULA,
+                age=40.0,
+                diameter_cm=20.0,
+                height_m=18.1,
+                weight_n=1.0,
+                uid="a2",
+            ),
+        ],
+    )
+
+    plot_b = CircularPlot(
+        id="b",
+        radius_m=12.0,
+        trees=[
+            Tree(
+                position=Position(5.0, 1.0, 0.5),
+                species=BETULA_PENDULA,
+                age=Age.TOTAL(55),
+                diameter_cm=Diameter_cm(30.0, measurement_height_m=1.5),
+                height_m=None,
+                weight_n=0.75,
+                uid="b1",
+            ),
+            Tree(
+                position=None,
+                species=None,
+                age=None,
+                diameter_cm=None,
+                height_m=None,
+                weight_n=1.0,
+                uid="b2",
+            ),
+        ],
+    )
+
+    stand_snapshots = snapshot_stand(type("MockStand", (), {"plots": [plot_a, plot_b]})())
+    assert len(stand_snapshots) == 4
+
+    restored = restore_stand(snapshot.to_dict() for snapshot in stand_snapshots)
+
+    original_trees = plot_a.trees + plot_b.trees
+    assert [tree.uid for tree in restored] == [tree.uid for tree in original_trees]
+
+    original_species = Counter(
+        tree.species.code if tree.species else None for tree in original_trees
+    )
+    restored_species = Counter(tree.species.code if tree.species else None for tree in restored)
+    assert restored_species == original_species
+
+    original_plot_snapshot = snapshot_plot(plot_a)
+    restored_plot = restore_plot(original_plot_snapshot)
+    assert [tree.uid for tree in restored_plot] == [tree.uid for tree in plot_a.trees]
+
+
+def test_snapshot_stand_uses_iterator():
+    class IterableStand:
+        def __init__(self, plots):
+            self.plots = plots
+
+        def __iter__(self):
+            return iter(self.plots)
+
+    plot = CircularPlot(
+        id="iter",
+        radius_m=8.0,
+        trees=[Tree(uid="iter-tree")],
+    )
+    snapshots = snapshot_stand(IterableStand([plot]))
+    assert len(snapshots) == 1
+    assert snapshots[0].to_dict()["uid"] == "iter-tree"
+
+
+def test_restore_tree_handles_incomplete_metadata():
+    base_tree = Tree(
+        species=PINUS_SYLVESTRIS,
+        age=Age.TOTAL(45),
+        diameter_cm=Diameter_cm(21.0),
+    )
+
+    payload = serialize_tree(base_tree)
+
+    string_species_tree = Tree(uid="string-species")
+    string_species_tree.species = "Pinus sylvestris"
+    string_payload = serialize_tree(string_species_tree)
+    assert string_payload["species"]["code"] is None
+    assert string_payload["species"]["full_name"] == "Pinus sylvestris"
+
+    code_removed = payload | {"species": {"code": None, "full_name": base_tree.species.full_name}}
+    restored_from_name = restore_tree(code_removed)
+    assert restored_from_name.species == base_tree.species
+
+    invalid_species = payload | {"species": {"code": "NOPE", "full_name": "not real"}}
+    restored_invalid_species = restore_tree(invalid_species)
+    assert restored_invalid_species.species is None
+
+    missing_measurement = payload | {
+        "age": {"kind": "measurement", "value": None, "code": Age.TOTAL.value}
+    }
+    restored_missing_measurement = restore_tree(missing_measurement)
+    assert restored_missing_measurement.age is None
+
+    fallback_measurement = payload | {
+        "age": {"kind": "mystery", "value": 12.0, "code": Age.DBH.value}
+    }
+    restored_fallback_age = restore_tree(fallback_measurement)
+    assert isinstance(restored_fallback_age.age, AgeMeasurement)
+    assert float(restored_fallback_age.age) == pytest.approx(12.0)
+    assert restored_fallback_age.age.code == Age.DBH.value
+
+    bad_numeric_age = payload | {"age": {"kind": "numeric", "value": None, "code": None}}
+    restored_bad_numeric_age = restore_tree(bad_numeric_age)
+    assert restored_bad_numeric_age.age is None
+
+    non_numeric_value = payload | {"age": {"kind": "weird", "value": "oops", "code": None}}
+    restored_non_numeric_age = restore_tree(non_numeric_value)
+    assert restored_non_numeric_age.age is None
+
+    missing_diameter_value = payload | {"diameter_cm": {"kind": "numeric", "value": None}}
+    restored_missing_diameter = restore_tree(missing_diameter_value)
+    assert restored_missing_diameter.diameter_cm is None
+
+    invalid_diameter_value = payload | {"diameter_cm": {"kind": "numeric", "value": "bad"}}
+    restored_invalid_diameter = restore_tree(invalid_diameter_value)
+    assert restored_invalid_diameter.diameter_cm is None


### PR DESCRIPTION
## Summary
- add a simulation package with documentation for checkpoint formats and storage guidance
- implement TreeCheckpoint serialization helpers plus batch snapshot/restore utilities
- add tests covering tree, plot, and stand round trips including degraded metadata cases

## Testing
- ruff check . --fix
- ruff format .
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50


------
https://chatgpt.com/codex/tasks/task_e_68e913ff63d8832998a25207a7c37db7