### PR TITLE
Add growth module factory and registry

### DIFF
--- a/src/pyforestry/simulation/__init__.py
+++ b/src/pyforestry/simulation/__init__.py
@@ -1,0 +1,5 @@
+"""Simulation utilities for managing growth models."""
+
+from .growth_module import GrowthModule, GrowthRegistry
+
+__all__ = ["GrowthModule", "GrowthRegistry"]

--- a/src/pyforestry/simulation/growth_module.py
+++ b/src/pyforestry/simulation/growth_module.py
@@ -1,0 +1,358 @@
+"""Utilities for instantiating and organising growth model implementations.
+
+The :class:`GrowthModule` class acts as a light-weight factory around an
+underlying growth model class.  It provides structured metadata, optional input
+validation hooks and a :meth:`create_instance` method that can be used by
+simulation pipelines to safely instantiate configured models.
+
+Wrapping existing models
+========================
+The factory is intentionally minimal so that existing model implementations can
+be wrapped without code changes.  For example, the
+:class:`~pyforestry.sweden.models.elfving_hagglund_1975.ElfvingHagglundInitialStand`
+model exposes static helpers for estimating young stand properties.  It can be
+wrapped as follows::
+
+    from dataclasses import dataclass
+    from pyforestry.simulation import GrowthModule, GrowthRegistry
+    from pyforestry.sweden.models.elfving_hagglund_1975 import (
+        ElfvingHagglundInitialStand,
+    )
+
+    @dataclass
+    class StandConfig:
+        latitude: float
+        altitude: float
+        dominant_height: float
+
+    elfving_module = GrowthModule(
+        ElfvingHagglundInitialStand,
+        name="elfving_initial",
+        description="Initial stand heuristics for Sweden (Elfving & Hägglund 1975)",
+        parameter_schema=StandConfig,
+        capability_tags={"sweden", "initial", "stand"},
+    )
+
+    registry = GrowthRegistry()
+    registry.register(elfving_module)
+
+    model = registry.get("elfving_initial").create_instance()
+
+The registry handles name resolution and tag based discovery for higher-level
+simulation orchestration.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import fields, is_dataclass
+from inspect import Parameter, Signature, signature
+from types import MappingProxyType
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Type,
+    TypeVar,
+)
+
+try:  # pragma: no cover - optional dependency detection
+    from pydantic import BaseModel as _PydanticBaseModel
+    from pydantic import ValidationError as _PydanticValidationError
+except Exception:  # pragma: no cover - we treat pydantic as optional
+    _PydanticBaseModel = None
+    _PydanticValidationError = Exception
+
+T = TypeVar("T")
+Validator = Callable[[Mapping[str, Any]], None]
+
+
+class GrowthModule(Generic[T]):
+    """Factory and metadata wrapper for growth model implementations.
+
+    Parameters
+    ----------
+    model_cls:
+        The concrete class implementing the growth model.
+    name:
+        Optional canonical identifier.  Defaults to the model class name in
+        snake case.
+    description:
+        Human readable description of the module.
+    parameter_schema:
+        Optional dataclass or :mod:`pydantic` model used to validate input
+        arguments for :meth:`create_instance`.
+    capability_tags:
+        Informational tags describing the model (e.g. geography, species).
+    metadata:
+        Arbitrary metadata stored alongside the module definition.
+    validators:
+        Iterable of callables that receive the normalised keyword arguments prior
+        to instantiation.  Validators may raise :class:`ValueError` to reject an
+        input configuration.
+    """
+
+    model_cls: Type[T]
+    name: str
+    description: Optional[str]
+    metadata: Mapping[str, Any]
+    capability_tags: frozenset[str]
+    validators: tuple[Validator, ...]
+
+    def __init__(
+        self,
+        model_cls: Type[T],
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        parameter_schema: Optional[Type[Any]] = None,
+        capability_tags: Optional[Iterable[str]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+        validators: Optional[Iterable[Validator]] = None,
+    ) -> None:
+        if not isinstance(model_cls, type):
+            raise TypeError("model_cls must be a class type")
+
+        self.model_cls = model_cls
+        self.name = name or self._default_name(model_cls.__name__)
+        self.description = description
+        self.capability_tags = frozenset(capability_tags or ())
+        self.metadata = MappingProxyType(dict(metadata or {}))
+        self.validators = tuple(validators or ())
+
+        self._signature = self._resolve_signature(model_cls)
+        self._schema_type = parameter_schema
+        self._schema_kind = self._infer_schema_kind(parameter_schema)
+
+    @staticmethod
+    def _default_name(name: str) -> str:
+        snake = []
+        for char in name:
+            if char.isupper() and snake:
+                snake.append("_")
+            snake.append(char.lower())
+        return "".join(snake) or name
+
+    @staticmethod
+    def _resolve_signature(model_cls: Type[T]) -> Signature:
+        try:
+            sig = signature(model_cls)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise TypeError(f"Unable to inspect constructor for {model_cls!r}") from exc
+        return sig
+
+    @staticmethod
+    def _infer_schema_kind(schema: Optional[Type[Any]]) -> Optional[str]:
+        if schema is None:
+            return None
+        if is_dataclass(schema):
+            return "dataclass"
+        if (
+            _PydanticBaseModel is not None
+            and isinstance(schema, type)
+            and issubclass(schema, _PydanticBaseModel)
+        ):
+            return "pydantic"
+        raise TypeError("parameter_schema must be a dataclass or pydantic model")
+
+    @property
+    def signature(self) -> Signature:
+        """Return the constructor signature for the wrapped model."""
+
+        return self._signature
+
+    def validate_parameters(self, **kwargs: Any) -> Dict[str, Any]:
+        """Validate keyword arguments and return a normalised mapping.
+
+        The validation workflow is as follows:
+
+        1. If a ``parameter_schema`` was supplied, instantiate it to perform
+           structural validation.  Dataclasses provide shape validation whereas
+           :mod:`pydantic` models additionally perform runtime type checking when
+           available.
+        2. The constructor signature of ``model_cls`` is consulted to ensure that
+           only supported arguments are provided and that mandatory arguments are
+           present.
+        3. User supplied ``validators`` are executed with the normalised keyword
+           arguments.
+
+        Returns
+        -------
+        dict
+            Normalised keyword arguments that can safely be passed to
+            :class:`model_cls`.
+        """
+
+        normalised = self._apply_schema(kwargs)
+        bound = self._bind_arguments(normalised)
+        required_missing = [
+            name
+            for name, param in self._signature.parameters.items()
+            if self._is_required_parameter(name, param) and name not in bound.arguments
+        ]
+        if required_missing:
+            raise ValueError("Missing required parameters: " + ", ".join(sorted(required_missing)))
+        for validator in self.validators:
+            validator(normalised)
+        return normalised
+
+    def _apply_schema(self, kwargs: Mapping[str, Any]) -> Dict[str, Any]:
+        if self._schema_kind is None:
+            return dict(kwargs)
+        if self._schema_kind == "dataclass":
+            try:
+                schema_obj = self._schema_type(**kwargs)  # type: ignore[misc]
+            except TypeError as exc:
+                raise ValueError(str(exc)) from exc
+            return {field.name: getattr(schema_obj, field.name) for field in fields(schema_obj)}
+        if self._schema_kind == "pydantic":
+            try:
+                schema_obj = self._schema_type(**kwargs)  # type: ignore[misc]
+            except _PydanticValidationError as exc:  # pragma: no cover - depends on pydantic
+                raise ValueError(str(exc)) from exc
+            if hasattr(schema_obj, "model_dump"):
+                return schema_obj.model_dump()
+            if hasattr(schema_obj, "dict"):
+                return schema_obj.dict()
+            return dict(kwargs)
+        raise RuntimeError("Unsupported schema kind")  # pragma: no cover - defensive
+
+    def _bind_arguments(self, kwargs: Mapping[str, Any]):
+        try:
+            return self._signature.bind_partial(**kwargs)
+        except TypeError as exc:
+            raise ValueError(str(exc)) from exc
+
+    @staticmethod
+    def _is_required_parameter(name: str, param: Parameter) -> bool:
+        if name == "self":
+            return False
+        if param.kind in (Parameter.VAR_KEYWORD, Parameter.VAR_POSITIONAL):
+            return False
+        return param.default is Parameter.empty
+
+    def create_instance(self, **kwargs: Any) -> T:
+        """Instantiate the wrapped model after validating ``kwargs``."""
+
+        params = self.validate_parameters(**kwargs)
+        return self.model_cls(**params)
+
+    def describe(self) -> Mapping[str, Any]:
+        """Return a serialisable description of the module."""
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "capability_tags": sorted(self.capability_tags),
+            "metadata": dict(self.metadata),
+            "model": f"{self.model_cls.__module__}.{self.model_cls.__qualname__}",
+        }
+
+
+class GrowthRegistry:
+    """Registry for organising and discovering growth modules."""
+
+    def __init__(self) -> None:
+        self._modules: Dict[str, GrowthModule[Any]] = {}
+        self._families: Dict[str, set[str]] = defaultdict(set)
+
+    def register(
+        self,
+        module: GrowthModule[Any],
+        *,
+        name: Optional[str] = None,
+        aliases: Optional[Iterable[str]] = None,
+        family: Optional[str] = None,
+        overwrite: bool = False,
+    ) -> GrowthModule[Any]:
+        """Register ``module`` under ``name`` and optional ``aliases``."""
+
+        resolved_name = name or module.name
+        if not resolved_name:
+            raise ValueError("A module name must be provided")
+        self._store_module(resolved_name, module, overwrite)
+        if aliases:
+            for alias in aliases:
+                self._store_module(alias, module, overwrite)
+        if family:
+            self._families[family].add(resolved_name)
+        return module
+
+    def _store_module(self, name: str, module: GrowthModule[Any], overwrite: bool) -> None:
+        if not overwrite and name in self._modules:
+            raise KeyError(f"A module named '{name}' is already registered")
+        self._modules[name] = module
+
+    def register_family(
+        self,
+        family: str,
+        modules: Mapping[str, GrowthModule[Any]] | Iterable[tuple[str, GrowthModule[Any]]],
+        *,
+        prefix_names: bool = True,
+        overwrite: bool = False,
+    ) -> Mapping[str, GrowthModule[Any]]:
+        """Register a collection of modules under a logical family name."""
+
+        if isinstance(modules, Mapping):
+            items = modules.items()
+        else:
+            items = list(modules)
+        registered: Dict[str, GrowthModule[Any]] = {}
+        for short_name, module in items:
+            full_name = f"{family}.{short_name}" if prefix_names else short_name
+            self.register(module, name=full_name, family=family, overwrite=overwrite)
+            registered[full_name] = module
+        return registered
+
+    def get(self, name: str) -> GrowthModule[Any]:
+        """Return the module registered under ``name``."""
+
+        try:
+            return self._modules[name]
+        except KeyError as exc:
+            raise KeyError(f"Unknown module '{name}'") from exc
+
+    def find_by_tags(
+        self, tags: Iterable[str], *, match_all: bool = True
+    ) -> list[GrowthModule[Any]]:
+        """Return modules matching the provided capability ``tags``."""
+
+        query = frozenset(tags)
+        if not query:
+            return list(self._modules.values())
+        matches: list[GrowthModule[Any]] = []
+        for module in dict.fromkeys(self._modules.values()):
+            if match_all and not query.issubset(module.capability_tags):
+                continue
+            if not match_all and module.capability_tags.isdisjoint(query):
+                continue
+            matches.append(module)
+        return matches
+
+    def iter_family(self, family: str) -> Iterator[GrowthModule[Any]]:
+        """Yield modules that were registered under ``family``."""
+
+        names = self._families.get(family, set())
+        for name in names:
+            yield self._modules[name]
+
+    def describe(self) -> Mapping[str, Any]:
+        """Return a serialisable snapshot of the registry."""
+
+        families = {
+            family: sorted(names)
+            for family, names in sorted(self._families.items(), key=lambda item: item[0])
+        }
+        modules = {
+            name: module.describe()
+            for name, module in sorted(self._modules.items(), key=lambda item: item[0])
+        }
+        return {"families": families, "modules": modules}
+
+
+__all__ = ["GrowthModule", "GrowthRegistry"]

--- a/tests/simulation/test_growth_module.py
+++ b/tests/simulation/test_growth_module.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import pytest
+
+from pyforestry.simulation import GrowthModule, GrowthRegistry
+from pyforestry.simulation import growth_module as growth_module_mod
+from pyforestry.sweden.models.elfving_hagglund_1975 import ElfvingHagglundInitialStand
+
+
+class DummyModel:
+    def __init__(self, foo: int, bar: float = 1.0) -> None:
+        self.foo = foo
+        self.bar = bar
+
+
+@dataclass
+class DummySchema:
+    foo: int
+    bar: float = 1.0
+
+
+def test_create_instance_validates_dataclass_schema():
+    module = GrowthModule(DummyModel, parameter_schema=DummySchema)
+
+    instance = module.create_instance(foo=10)
+
+    assert isinstance(instance, DummyModel)
+    assert instance.foo == 10
+    assert instance.bar == pytest.approx(1.0)
+
+
+def test_missing_required_parameter_raises_value_error():
+    module = GrowthModule(DummyModel, parameter_schema=DummySchema)
+
+    with pytest.raises(ValueError) as exc:
+        module.create_instance()
+
+    assert "foo" in str(exc.value)
+
+
+def test_unknown_argument_is_rejected():
+    module = GrowthModule(DummyModel, parameter_schema=DummySchema)
+
+    with pytest.raises(ValueError):
+        module.create_instance(foo=1, baz=2)
+
+
+def test_registry_resolves_by_name_and_tags():
+    module = GrowthModule(
+        ElfvingHagglundInitialStand,
+        name="elfving_initial",
+        capability_tags={"sweden", "initial", "stand"},
+    )
+    registry = GrowthRegistry()
+    registry.register(module, aliases=["sweden.initial"], family="sweden")
+
+    resolved = registry.get("elfving_initial")
+    assert resolved is module
+
+    tag_matches = registry.find_by_tags({"initial"})
+    assert module in tag_matches
+
+    family_modules = list(registry.iter_family("sweden"))
+    assert family_modules == [module]
+
+
+def test_register_family_prefixes_names():
+    module_a = GrowthModule(DummyModel, name="dummy_a")
+    module_b = GrowthModule(DummyModel, name="dummy_b")
+    registry = GrowthRegistry()
+
+    registered = registry.register_family(
+        "demo", {"a": module_a, "b": module_b}, prefix_names=True
+    )
+
+    assert set(registered.keys()) == {"demo.a", "demo.b"}
+    assert registry.get("demo.a") is module_a
+    assert registry.get("demo.b") is module_b
+
+
+def test_register_family_without_prefix_and_description_helpers():
+    module = GrowthModule(
+        DummyModel,
+        name="dummy",
+        description="Demo module",
+        capability_tags={"tag"},
+        metadata={"source": "unit-test"},
+    )
+    registry = GrowthRegistry()
+
+    registered = registry.register_family("demo", [("dummy", module)], prefix_names=False)
+
+    assert registered == {"dummy": module}
+    assert registry.describe()["families"]["demo"] == ["dummy"]
+    assert registry.describe()["modules"]["dummy"]["name"] == "dummy"
+    assert module.describe()["metadata"] == {"source": "unit-test"}
+
+
+def test_registry_duplicate_and_overwrite_behaviour():
+    module = GrowthModule(DummyModel, name="duplicate")
+    registry = GrowthRegistry()
+
+    registry.register(module, name="duplicate")
+    with pytest.raises(KeyError):
+        registry.register(module, name="duplicate")
+
+    registry.register(module, name="duplicate", overwrite=True)
+    module.name = ""
+    with pytest.raises(ValueError):
+        registry.register(module)
+    with pytest.raises(KeyError) as exc:
+        registry.get("missing")
+    assert "Unknown module" in str(exc.value)
+
+
+def test_registry_find_by_tags_variants():
+    module_one = GrowthModule(DummyModel, capability_tags={"alpha", "beta"})
+    module_two = GrowthModule(DummyModel, capability_tags={"beta"})
+    module_three = GrowthModule(DummyModel, capability_tags={"gamma"})
+    registry = GrowthRegistry()
+    registry.register(module_one, name="one")
+    registry.register(module_two, name="two")
+    registry.register(module_three, name="three")
+
+    assert registry.find_by_tags({"alpha"}) == [module_one]
+    assert set(registry.find_by_tags({"beta"}, match_all=False)) == {
+        module_one,
+        module_two,
+    }
+    assert set(registry.find_by_tags(set())) == {
+        module_one,
+        module_two,
+        module_three,
+    }
+    assert list(registry.iter_family("missing")) == []
+
+
+def test_module_validators_are_invoked():
+    calls: list[int] = []
+
+    def validator(params: Mapping[str, Any]) -> None:
+        calls.append(params["foo"])
+        if params["foo"] < 0:
+            raise ValueError("foo must be positive")
+
+    module = GrowthModule(DummyModel, parameter_schema=DummySchema, validators=[validator])
+
+    module.create_instance(foo=1)
+    with pytest.raises(ValueError):
+        module.create_instance(foo=-1)
+
+    assert calls == [1, -1]
+
+
+def test_module_without_schema_enforces_constructor_requirements():
+    class NeedsValue:
+        def __init__(self, value: int, other: float = 0.5) -> None:
+            self.value = value
+            self.other = other
+
+    module = GrowthModule(NeedsValue)
+
+    with pytest.raises(ValueError) as exc:
+        module.create_instance()
+
+    assert "value" in str(exc.value)
+
+
+def test_module_type_checks_and_signature_property():
+    module = GrowthModule(DummyModel, parameter_schema=DummySchema)
+
+    assert "foo" in str(module.signature)
+    assert module.name == "dummy_model"
+
+    with pytest.raises(TypeError):
+        GrowthModule(42)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError):
+        GrowthModule(DummyModel, parameter_schema=int)  # type: ignore[arg-type]
+
+
+def test_validate_parameters_reports_unknown_arguments():
+    module = GrowthModule(DummyModel)
+
+    with pytest.raises(ValueError):
+        module.validate_parameters(foo=1, baz=2)
+
+
+def test_pydantic_like_schema_support(monkeypatch: pytest.MonkeyPatch):
+    class FakeValidationError(Exception):
+        pass
+
+    class FakeBase:
+        def __init__(self, **data: Any) -> None:
+            self.data = data
+
+        def model_dump(self) -> Mapping[str, Any]:
+            return self.data
+
+    class FakeSchema(FakeBase):
+        pass
+
+    monkeypatch.setattr(growth_module_mod, "_PydanticBaseModel", FakeBase)
+    monkeypatch.setattr(growth_module_mod, "_PydanticValidationError", FakeValidationError)
+
+    module = GrowthModule(DummyModel, parameter_schema=FakeSchema)
+
+    instance = module.create_instance(foo=7)
+    assert isinstance(instance, DummyModel)
+    assert module._schema_kind == "pydantic"
+
+
+def test_pydantic_like_validation_error(monkeypatch: pytest.MonkeyPatch):
+    class FakeValidationError(Exception):
+        pass
+
+    class FakeBase:
+        def __init__(self, **data: Any) -> None:
+            if "foo" not in data:
+                raise FakeValidationError("foo required")
+            self.data = data
+
+        def dict(self) -> Mapping[str, Any]:
+            return self.data
+
+    class FakeSchema(FakeBase):
+        pass
+
+    monkeypatch.setattr(growth_module_mod, "_PydanticBaseModel", FakeBase)
+    monkeypatch.setattr(growth_module_mod, "_PydanticValidationError", FakeValidationError)
+
+    module = GrowthModule(DummyModel, parameter_schema=FakeSchema)
+
+    with pytest.raises(ValueError) as exc:
+        module.create_instance()
+
+    assert "foo required" in str(exc.value)
+
+
+def test_pydantic_like_schema_without_dump(monkeypatch: pytest.MonkeyPatch):
+    class FakeBase:
+        def __init__(self, **data: Any) -> None:
+            self.data = data
+
+    class FakeSchema(FakeBase):
+        pass
+
+    monkeypatch.setattr(growth_module_mod, "_PydanticBaseModel", FakeBase)
+    monkeypatch.setattr(growth_module_mod, "_PydanticValidationError", ValueError)
+
+    module = GrowthModule(DummyModel, parameter_schema=FakeSchema)
+
+    params = module.validate_parameters(foo=2)
+    assert params == {"foo": 2}
+
+
+def test_varargs_signature_is_supported():
+    class VarArgsModel:
+        def __init__(self, value: int, *args: Any, **kwargs: Any) -> None:
+            self.value = value
+
+    module = GrowthModule(VarArgsModel)
+
+    params = module.validate_parameters(value=3)
+    assert params == {"value": 3}
+    sig = module.signature
+    first_param = next(iter(sig.parameters.values()))
+    assert not module._is_required_parameter("self", first_param)
+    assert not module._is_required_parameter("args", sig.parameters["args"])
+    assert not module._is_required_parameter("kwargs", sig.parameters["kwargs"])
+
+
+def test_pydantic_like_schema_dict(monkeypatch: pytest.MonkeyPatch):
+    class FakeBase:
+        def __init__(self, **data: Any) -> None:
+            self.data = data
+
+        def dict(self) -> Mapping[str, Any]:
+            return self.data
+
+    class FakeSchema(FakeBase):
+        pass
+
+    monkeypatch.setattr(growth_module_mod, "_PydanticBaseModel", FakeBase)
+    monkeypatch.setattr(growth_module_mod, "_PydanticValidationError", ValueError)
+
+    module = GrowthModule(DummyModel, parameter_schema=FakeSchema)
+
+    params = module.validate_parameters(foo=5)
+    assert params == {"foo": 5}


### PR DESCRIPTION
## Summary
- add a `GrowthModule` factory with validation hooks and a companion `GrowthRegistry` for tag-based discovery
- expose the simulation helpers through `pyforestry.simulation` for downstream imports
- exercise growth module validation, registry behaviour, and optional pydantic support in new tests

## Testing
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50

------
https://chatgpt.com/codex/tasks/task_e_68e9140059a883299fc4569783a25221