### PR TITLE
Add simulation framework primitives and tests

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,8 @@ pyforestry Documentation
 
    api/modules
    helpers_overview
+   reference/simulation
+   reference/simulation_rules
    notebooks/tree_species_intro
    notebooks/timber_bucking_demo
    notebooks/stand_site_enum_demo

--- a/docs/source/reference/simulation.rst
+++ b/docs/source/reference/simulation.rst
@@ -1,0 +1,106 @@
+Simulation framework
+====================
+
+The :mod:`pyforestry.simulation` package provides the primitives required to
+build deterministic growth simulations. It introduces immutable snapshot data
+structures, checkpoint utilities and the orchestration manager that coordinates
+modules, rules and seed policies.
+
+State snapshots
+---------------
+
+.. autoclass:: pyforestry.simulation.TreeState
+   :members:
+
+.. autoclass:: pyforestry.simulation.PlotState
+   :members:
+
+.. autoclass:: pyforestry.simulation.StandState
+   :members:
+
+Checkpointing
+-------------
+
+.. autoclass:: pyforestry.simulation.TreeCheckpointer
+   :members:
+
+.. autoclass:: pyforestry.simulation.SimulationCheckpoint
+   :members:
+
+Growth modules
+--------------
+
+.. autoclass:: pyforestry.simulation.GrowthModule
+   :members:
+
+.. autoclass:: pyforestry.simulation.ModelResult
+   :members:
+
+Simulation manager
+------------------
+
+.. autoclass:: pyforestry.simulation.SimulationManager
+   :members:
+
+Seed policies
+-------------
+
+.. autoclass:: pyforestry.simulation.SeedPolicy
+   :members:
+
+.. autoclass:: pyforestry.simulation.FixedSeedPolicy
+   :members:
+
+.. autoclass:: pyforestry.simulation.PerModuleOffsetPolicy
+   :members:
+
+.. autoclass:: pyforestry.simulation.RollingSeedPolicy
+   :members:
+
+Quick start example
+-------------------
+
+.. code-block:: python
+
+   from pyforestry.base.helpers import CircularPlot, Stand, Tree
+   from pyforestry.base.helpers.primitives.cartesian_position import Position
+   from pyforestry.simulation import GrowthModule, SimulationManager
+
+   # Define a very small stand
+   trees = [Tree(uid="t1", species="picea abies", diameter_cm=32, age=40)]
+   plot = CircularPlot(id="p1", radius_m=5.0, position=Position(0, 0), trees=trees)
+   stand = Stand(area_ha=1.0, plots=[plot])
+
+   # Implement a trivial growth model
+   class IncrementDiameter:
+       level = "tree"
+       time_step = 1.0
+       requires_checkpoint = False
+       required_tree_fields = ("diameter_cm",)
+       required_stand_fields = ()
+
+       def __init__(self, increment: float = 1.0) -> None:
+           self.increment = increment
+
+       def validate_inputs(self, stand_state, tree_states) -> None:
+           for tree_state in tree_states:
+               if tree_state.diameter_cm is None:
+                   raise ValueError("Missing diameter")
+
+       def initialize(self, context=None) -> None:
+           pass
+
+       def step(self, years, rng, stand_state, tree_states):
+           deltas = {tree.uid: {"diameter_cm": years * self.increment} for tree in tree_states}
+           return ModelResult(tree_deltas=deltas)
+
+       def finalize(self) -> None:
+           pass
+
+   module = GrowthModule(IncrementDiameter, config={"increment": 2.0})
+   manager = SimulationManager()
+   manager.register_stand("demo", stand, modules=[module])
+   manager.start_run()
+   manager.run(years=1.0, stand_ids=["demo"])
+
+   print(stand.plots[0].trees[0].diameter_cm)  # 34.0

--- a/docs/source/reference/simulation_rules.rst
+++ b/docs/source/reference/simulation_rules.rst
@@ -1,0 +1,55 @@
+Simulation rules engine
+=======================
+
+The rules engine coordinates conditional actions that can operate on individual
+stands or groups of stands. Rules are evaluated against immutable
+:class:`~pyforestry.simulation.StandState` objects produced by the
+:class:`~pyforestry.simulation.TreeCheckpointer` so predicate logic always sees a
+stable snapshot of the current state.
+
+Core abstractions
+-----------------
+
+.. autoclass:: pyforestry.simulation.Rule
+   :members:
+
+.. autoclass:: pyforestry.simulation.RuleAction
+   :members:
+
+.. autoclass:: pyforestry.simulation.RuleDecision
+   :members:
+
+.. autoclass:: pyforestry.simulation.RuleSet
+   :members:
+
+Example
+-------
+
+The example below demonstrates how to thin the largest tree whenever total stem
+counts exceed a threshold.
+
+.. code-block:: python
+
+   from pyforestry.simulation import Rule, RuleAction, RuleSet
+
+   def overstocked(state):
+       return state.metric_estimates["Stems"]["TOTAL"] > 250
+
+   def remove_largest(manager, stand_id, state):
+       record = manager._require_stand(stand_id)  # application code would wrap this helper
+       first_plot = state.plots[0]
+       record.stand.thin_trees(uids=[first_plot.tree_uids[0]])
+
+   ruleset = RuleSet(
+       name="thinning",
+       rules=[
+           Rule(
+               name="remove-largest",
+               predicate=overstocked,
+               actions=[RuleAction(name="thin", callback=remove_largest)],
+           )
+       ],
+       scope={"tags": ["thinning"]},
+   )
+
+   manager.register_ruleset("thinning", ruleset)

--- a/src/pyforestry/__init__.py
+++ b/src/pyforestry/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for pyforestry."""
 
-from . import base, sweden
+from . import base, simulation, sweden
 
-__all__ = ["base", "sweden"]
+__all__ = ["base", "simulation", "sweden"]

--- a/src/pyforestry/simulation/__init__.py
+++ b/src/pyforestry/simulation/__init__.py
@@ -1,0 +1,33 @@
+"""Simulation framework primitives for pyforestry."""
+
+from .checkpoint import SimulationCheckpoint, TreeCheckpointer
+from .growth import GrowthModelProtocol, GrowthModule, ModelResult
+from .manager import SimulationManager
+from .rules import Rule, RuleAction, RuleDecision, RuleSet
+from .seeding import (
+    FixedSeedPolicy,
+    PerModuleOffsetPolicy,
+    RollingSeedPolicy,
+    SeedPolicy,
+)
+from .state import PlotState, StandState, TreeState
+
+__all__ = [
+    "SimulationCheckpoint",
+    "TreeCheckpointer",
+    "GrowthModelProtocol",
+    "GrowthModule",
+    "ModelResult",
+    "SimulationManager",
+    "Rule",
+    "RuleAction",
+    "RuleDecision",
+    "RuleSet",
+    "SeedPolicy",
+    "FixedSeedPolicy",
+    "PerModuleOffsetPolicy",
+    "RollingSeedPolicy",
+    "TreeState",
+    "PlotState",
+    "StandState",
+]

--- a/src/pyforestry/simulation/checkpoint.py
+++ b/src/pyforestry/simulation/checkpoint.py
@@ -1,0 +1,249 @@
+"""Checkpointing utilities for simulation runs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Mapping, Sequence
+
+from pyforestry.base.helpers import CircularPlot, Stand, Tree
+from pyforestry.base.helpers.primitives.cartesian_position import Position
+
+from .state import PlotState, StandState, TreeState
+
+__all__ = ["SimulationCheckpoint", "TreeCheckpointer"]
+
+
+def _to_tuple(position: Position | tuple[float, ...] | None) -> tuple[float, ...] | None:
+    """Convert a :class:`Position` object to a plain tuple."""
+
+    if position is None:
+        return None
+    if isinstance(position, tuple):
+        return position
+    coords = [position.X, position.Y]
+    if position.Z not in (None, 0, 0.0):
+        coords.append(position.Z)
+    return tuple(coords)
+
+
+def _normalise_scalar(value: Any) -> float | Any | None:
+    """Attempt to coerce metric values into floats for serialisation."""
+
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    for attr in ("value", "values"):
+        maybe = getattr(value, attr, None)
+        if isinstance(maybe, (int, float)):
+            return float(maybe)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return value
+
+
+@dataclass(slots=True)
+class SimulationCheckpoint:
+    """Bundle of stand and tree snapshots captured at a point in time."""
+
+    timestamp: datetime
+    seed_state: Mapping[str, Any]
+    tree_states: Sequence[TreeState]
+    stand_state: StandState
+    active_modules: Sequence[str] = field(default_factory=tuple)
+    pending_events: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the checkpoint into a serialisable dictionary."""
+
+        return {
+            "timestamp": self.timestamp.isoformat(),
+            "seed_state": dict(self.seed_state),
+            "tree_states": [asdict(ts) for ts in self.tree_states],
+            "stand_state": asdict(self.stand_state),
+            "active_modules": list(self.active_modules),
+            "pending_events": [dict(ev) for ev in self.pending_events],
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SimulationCheckpoint":
+        """Recreate a checkpoint from a serialised dictionary."""
+
+        tree_states = [TreeState(**ts) for ts in payload["tree_states"]]
+        plots = tuple(PlotState(**plot) for plot in payload["stand_state"].get("plots", ()))
+        stand_state = StandState(
+            site=payload["stand_state"].get("site"),
+            area_ha=payload["stand_state"].get("area_ha"),
+            top_height_definition=payload["stand_state"].get("top_height_definition"),
+            attrs=payload["stand_state"].get("attrs", {}),
+            metric_estimates=payload["stand_state"].get("metric_estimates", {}),
+            use_angle_count=payload["stand_state"].get("use_angle_count", False),
+            plots=plots,
+        )
+        return cls(
+            timestamp=datetime.fromisoformat(payload["timestamp"]),
+            seed_state=payload.get("seed_state", {}),
+            tree_states=tree_states,
+            stand_state=stand_state,
+            active_modules=payload.get("active_modules", ()),
+            pending_events=payload.get("pending_events", ()),
+            metadata=payload.get("metadata", {}),
+        )
+
+
+class TreeCheckpointer:
+    """Helper responsible for converting live objects to snapshot dataclasses."""
+
+    def __init__(self, tree_factory: type[Tree] | None = None):
+        self._tree_factory = tree_factory or Tree
+
+    def capture_tree_states(self, stand: Stand) -> List[TreeState]:
+        """Extract :class:`TreeState` objects from every plot in ``stand``."""
+
+        tree_states: List[TreeState] = []
+        for plot in stand.plots:
+            for tree in plot.trees:
+                position = _to_tuple(tree.position)
+                species = getattr(tree.species, "full_name", None)
+                tree_states.append(
+                    TreeState(
+                        uid=tree.uid,
+                        species=species,
+                        age=_normalise_scalar(tree.age),
+                        diameter_cm=_normalise_scalar(tree.diameter_cm),
+                        height_m=_normalise_scalar(tree.height_m),
+                        weight_n=float(tree.weight_n) if tree.weight_n is not None else 0.0,
+                        position=position,
+                        plot_id=plot.id,
+                    )
+                )
+        return tree_states
+
+    def capture_stand_state(self, stand: Stand) -> StandState:
+        """Create a :class:`StandState` snapshot for ``stand``."""
+
+        if not stand.use_angle_count:
+            stand._compute_ht_estimates()
+
+        metric_estimates: Dict[str, Dict[str, float]] = {}
+        for metric, values in stand._metric_estimates.items():
+            metric_estimates[metric] = {}
+            for species, measurement in values.items():
+                if species == "TOTAL":
+                    species_key = "TOTAL"
+                else:
+                    species_key = getattr(species, "full_name", str(species))
+                metric_estimates[metric][species_key] = _normalise_scalar(measurement)
+
+        plots: List[PlotState] = []
+        for plot in stand.plots:
+            position = _to_tuple(plot.position)
+            plots.append(
+                PlotState(
+                    id=plot.id,
+                    area_m2=getattr(plot, "area_m2", None),
+                    radius_m=getattr(plot, "radius_m", None),
+                    occlusion=plot.occlusion,
+                    position=position,
+                    site=plot.site,
+                    tree_uids=tuple(tree.uid for tree in plot.trees),
+                    angle_counts=tuple(plot.AngleCount),
+                )
+            )
+
+        return StandState(
+            site=stand.site,
+            area_ha=stand.area_ha,
+            top_height_definition=stand.top_height_definition,
+            attrs=dict(stand.attrs),
+            metric_estimates=metric_estimates,
+            use_angle_count=stand.use_angle_count,
+            plots=tuple(plots),
+        )
+
+    def create_checkpoint(
+        self,
+        stand: Stand,
+        *,
+        seed_state: Mapping[str, Any] | None = None,
+        active_modules: Sequence[str] | None = None,
+        pending_events: Sequence[Mapping[str, Any]] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        timestamp: datetime | None = None,
+    ) -> SimulationCheckpoint:
+        """Capture a :class:`SimulationCheckpoint` for ``stand``."""
+
+        tree_states = self.capture_tree_states(stand)
+        stand_state = self.capture_stand_state(stand)
+        return SimulationCheckpoint(
+            timestamp=timestamp or datetime.utcnow(),
+            seed_state=seed_state or {},
+            tree_states=tuple(tree_states),
+            stand_state=stand_state,
+            active_modules=tuple(active_modules or ()),
+            pending_events=tuple(pending_events or ()),
+            metadata=metadata or {},
+        )
+
+    def restore(self, stand: Stand, checkpoint: SimulationCheckpoint) -> None:
+        """Restore ``stand`` to the state described by ``checkpoint``."""
+
+        stand.site = checkpoint.stand_state.site
+        stand.area_ha = checkpoint.stand_state.area_ha
+        stand.top_height_definition = checkpoint.stand_state.top_height_definition
+        stand.attrs = dict(checkpoint.stand_state.attrs)
+        stand.use_angle_count = checkpoint.stand_state.use_angle_count
+
+        tree_by_plot: Dict[Any, List[TreeState]] = {}
+        for tree_state in checkpoint.tree_states:
+            tree_by_plot.setdefault(tree_state.plot_id, []).append(tree_state)
+
+        new_plots: List[CircularPlot] = []
+        for plot_state in checkpoint.stand_state.plots:
+            position = None
+            if plot_state.position is not None:
+                position = Position(*plot_state.position)
+            trees: List[Tree] = []
+            for tree_state in tree_by_plot.get(plot_state.id, []):
+                tree = self._tree_factory(
+                    position=Position(*tree_state.position) if tree_state.position else None,
+                    species=tree_state.species,
+                    age=tree_state.age,
+                    diameter_cm=tree_state.diameter_cm,
+                    height_m=tree_state.height_m,
+                    weight_n=tree_state.weight_n,
+                    uid=tree_state.uid,
+                )
+                trees.append(tree)
+            plot = CircularPlot(
+                id=plot_state.id,
+                occlusion=plot_state.occlusion,
+                position=position,
+                radius_m=plot_state.radius_m,
+                area_m2=plot_state.area_m2,
+                site=plot_state.site,
+                trees=trees,
+            )
+            plot.AngleCount = list(plot_state.angle_counts)
+            new_plots.append(plot)
+
+        stand.plots = new_plots
+        stand._metric_estimates.clear()
+        if stand.plots and not stand.use_angle_count:
+            stand._compute_ht_estimates()
+
+    def diff_tree_uids(
+        self, checkpoint: SimulationCheckpoint, stand: Stand
+    ) -> Dict[str, set[str | int | None]]:
+        """Return additions and removals when comparing a checkpoint to ``stand``."""
+
+        live_uids = {tree.uid for plot in stand.plots for tree in plot.trees}
+        snapshot_uids = {state.uid for state in checkpoint.tree_states}
+        return {
+            "added": {uid for uid in live_uids if uid not in snapshot_uids},
+            "removed": {uid for uid in snapshot_uids if uid not in live_uids},
+        }

--- a/src/pyforestry/simulation/growth.py
+++ b/src/pyforestry/simulation/growth.py
@@ -1,0 +1,201 @@
+"""Growth model protocol and module factory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from inspect import Parameter, Signature, signature
+from typing import Any, ClassVar, Dict, Literal, Mapping, Protocol, Sequence
+
+import numpy as np
+
+from .state import StandState, TreeState, TreeStateSequence
+
+__all__ = ["GrowthModelProtocol", "ModelResult", "GrowthModule"]
+
+
+@dataclass(slots=True)
+class ModelResult:
+    """Container capturing the outcome of a growth model step."""
+
+    tree_deltas: Mapping[str | int | None, Mapping[str, float]] = field(default_factory=dict)
+    stand_deltas: Mapping[str, float] = field(default_factory=dict)
+    metadata: Mapping[str, Any] | None = None
+
+    def merge(self, other: "ModelResult") -> "ModelResult":
+        """Combine two results, giving precedence to ``other`` on conflicts."""
+
+        merged_tree: Dict[str | int | None, Dict[str, float]] = {
+            key: dict(value) for key, value in self.tree_deltas.items()
+        }
+        for uid, deltas in other.tree_deltas.items():
+            merged_tree.setdefault(uid, {}).update(deltas)
+
+        merged_stand = dict(self.stand_deltas)
+        merged_stand.update(other.stand_deltas)
+
+        merged_metadata = dict(self.metadata or {})
+        merged_metadata.update(other.metadata or {})
+        return ModelResult(merged_tree, merged_stand, merged_metadata)
+
+
+class GrowthModelProtocol(Protocol):
+    """Structural protocol implemented by growth models."""
+
+    level: ClassVar[Literal["tree", "stand"]]
+    time_step: ClassVar[float]
+    requires_checkpoint: ClassVar[bool]
+    required_tree_fields: ClassVar[Sequence[str]]
+    required_stand_fields: ClassVar[Sequence[str]]
+
+    def __init__(self, **kwargs: Any) -> None: ...
+
+    def validate_inputs(self, stand_state: StandState, tree_states: TreeStateSequence) -> None: ...
+
+    def initialize(self, context: Mapping[str, Any] | None = None) -> None: ...
+
+    def step(
+        self,
+        years: float,
+        rng: np.random.Generator,
+        stand_state: StandState,
+        tree_states: TreeStateSequence,
+    ) -> ModelResult: ...
+
+    def finalize(self) -> None: ...
+
+
+def _normalise_class_attr(cls: type, name: str, default: Any) -> Any:
+    value = getattr(cls, name, None)
+    return default if value is None else value
+
+
+class GrowthModule:
+    """Factory responsible for validating and instantiating growth models."""
+
+    def __init__(
+        self,
+        model_cls: type[GrowthModelProtocol],
+        *,
+        name: str | None = None,
+        config: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.model_cls = model_cls
+        self.name = name or model_cls.__name__
+        self.config: Dict[str, Any] = dict(config or {})
+        self.level: Literal["tree", "stand"] = _normalise_class_attr(model_cls, "level", "tree")
+        self.time_step: float = float(_normalise_class_attr(model_cls, "time_step", 1.0))
+        self.requires_checkpoint: bool = bool(
+            _normalise_class_attr(model_cls, "requires_checkpoint", False)
+        )
+        self.required_tree_fields = tuple(
+            _normalise_class_attr(model_cls, "required_tree_fields", ())
+        )
+        self.required_stand_fields = tuple(
+            _normalise_class_attr(model_cls, "required_stand_fields", ())
+        )
+        self._constructor_signature: Signature = signature(model_cls)
+        self._validate_config()
+
+    def _validate_config(self) -> None:
+        """Ensure provided configuration keys are accepted by the model."""
+
+        parameters = {
+            name
+            for name, param in self._constructor_signature.parameters.items()
+            if param.kind in (Parameter.POSITIONAL_OR_KEYWORD, Parameter.KEYWORD_ONLY)
+        }
+        unexpected = set(self.config) - parameters
+        if unexpected:
+            raise TypeError(
+                f"Configuration for {self.name} contains unexpected keys: {sorted(unexpected)}"
+            )
+
+    def schema(self) -> Mapping[str, str]:
+        """Expose constructor parameter information for documentation."""
+
+        return {
+            name: str(param.annotation)
+            for name, param in self._constructor_signature.parameters.items()
+            if param.kind in (Parameter.POSITIONAL_OR_KEYWORD, Parameter.KEYWORD_ONLY)
+        }
+
+    @classmethod
+    def from_config(
+        cls, model_cls: type[GrowthModelProtocol], config: Mapping[str, Any]
+    ) -> "GrowthModule":
+        """Create a module from configuration dictionary."""
+
+        return cls(model_cls=model_cls, config=config)
+
+    def _enrich_kwargs(self, **dependencies: Any) -> Dict[str, Any]:
+        merged = dict(self.config)
+        for key, value in dependencies.items():
+            if key in self._constructor_signature.parameters:
+                merged[key] = value
+        return merged
+
+    def instantiate(self, **dependencies: Any) -> GrowthModelProtocol:
+        """Materialise the growth model, injecting dependencies as required."""
+
+        kwargs = self._enrich_kwargs(**dependencies)
+        instance = self.model_cls(**kwargs)
+        return instance
+
+    def metadata(self) -> Mapping[str, Any]:
+        """Return metadata describing the module."""
+
+        return {
+            "name": self.name,
+            "level": self.level,
+            "time_step": self.time_step,
+            "requires_checkpoint": self.requires_checkpoint,
+            "required_tree_fields": self.required_tree_fields,
+            "required_stand_fields": self.required_stand_fields,
+        }
+
+    def validate_inputs(
+        self,
+        stand_state: StandState,
+        tree_states: TreeStateSequence,
+        *,
+        instance: GrowthModelProtocol | None = None,
+    ) -> GrowthModelProtocol:
+        """Ensure that snapshot data satisfies the model requirements."""
+
+        missing_tree_fields = self._missing_tree_fields(tree_states)
+        if missing_tree_fields:
+            raise ValueError(
+                f"Tree snapshots for module {self.name} are missing fields:"
+                f" {sorted(missing_tree_fields)}"
+            )
+
+        missing_stand_fields = self._missing_stand_fields(stand_state)
+        if missing_stand_fields:
+            raise ValueError(
+                f"Stand snapshot for module {self.name} is missing fields:"
+                f" {sorted(missing_stand_fields)}"
+            )
+
+        model = instance or self.instantiate()
+        model.validate_inputs(stand_state, tree_states)
+        return model
+
+    def _missing_tree_fields(self, tree_states: Sequence[TreeState]) -> set[str]:
+        if not self.required_tree_fields:
+            return set()
+        missing: set[str] = set()
+        for field_name in self.required_tree_fields:
+            for tree_state in tree_states:
+                if getattr(tree_state, field_name, None) is None:
+                    missing.add(field_name)
+                    break
+        return missing
+
+    def _missing_stand_fields(self, stand_state: StandState) -> set[str]:
+        if not self.required_stand_fields:
+            return set()
+        missing: set[str] = set()
+        for field_name in self.required_stand_fields:
+            if getattr(stand_state, field_name, None) in (None, {}):
+                missing.add(field_name)
+        return missing

--- a/src/pyforestry/simulation/manager.py
+++ b/src/pyforestry/simulation/manager.py
@@ -1,0 +1,195 @@
+"""Simulation manager orchestrating stands, modules and rules."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Sequence
+
+import numpy as np
+
+from pyforestry.base.helpers import Stand
+
+from .checkpoint import SimulationCheckpoint, TreeCheckpointer
+from .growth import GrowthModule, ModelResult
+from .rules import RuleSet
+from .seeding import FixedSeedPolicy, SeedPolicy
+
+__all__ = ["SimulationManager"]
+
+
+@dataclass
+class StandRecord:
+    stand: Stand
+    modules: List[GrowthModule] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+
+
+class SimulationManager:
+    """Coordinate growth models, rule execution and checkpointing."""
+
+    def __init__(
+        self,
+        *,
+        checkpointer: TreeCheckpointer | None = None,
+        seed_policy: SeedPolicy | None = None,
+        logger: Callable[[str], None] | None = None,
+    ) -> None:
+        self.checkpointer = checkpointer or TreeCheckpointer()
+        self.seed_policy = seed_policy
+        self.logger = logger
+        self._stands: Dict[str, StandRecord] = {}
+        self._rulesets: Dict[str, RuleSet] = {}
+        self._history: Dict[str, List[SimulationCheckpoint]] = defaultdict(list)
+        self._pending_events: Dict[str, List[Mapping[str, Any]]] = defaultdict(list)
+        self._audit_log: List[str] = []
+
+    def _audit(self, message: str) -> None:
+        self._audit_log.append(message)
+        if self.logger:
+            self.logger(message)
+
+    def register_stand(
+        self,
+        stand_id: str,
+        stand: Stand,
+        *,
+        modules: Sequence[GrowthModule] | None = None,
+        tags: Iterable[str] | None = None,
+    ) -> None:
+        if stand_id in self._stands:
+            raise KeyError(f"Stand '{stand_id}' already registered")
+        record = StandRecord(stand=stand, modules=list(modules or ()), tags=list(tags or ()))
+        self._stands[stand_id] = record
+        checkpoint = self.checkpointer.create_checkpoint(stand)
+        self._history[stand_id].append(checkpoint)
+        self._audit(f"Registered stand {stand_id} with {len(stand.plots)} plots")
+
+    def add_modules(self, stand_id: str, modules: Sequence[GrowthModule]) -> None:
+        record = self._require_stand(stand_id)
+        record.modules.extend(modules)
+        self._audit(f"Added {len(modules)} modules to stand {stand_id}")
+
+    def register_ruleset(self, name: str, ruleset: RuleSet) -> None:
+        self._rulesets[name] = ruleset
+        self._audit(f"Registered ruleset '{name}'")
+
+    def queue_event(self, stand_id: str, event: Mapping[str, Any]) -> None:
+        self._pending_events[stand_id].append(dict(event))
+
+    def start_run(self, seed_policy: SeedPolicy | None = None) -> None:
+        if seed_policy is not None:
+            self.seed_policy = seed_policy
+        if self.seed_policy is None:
+            self.seed_policy = FixedSeedPolicy(0)
+        self.seed_policy.start_run()
+        self._audit("Simulation run started")
+
+    def run(
+        self,
+        years: float,
+        *,
+        stand_ids: Sequence[str] | None = None,
+        checkpoint_interval: float | None = None,
+    ) -> None:
+        if self.seed_policy is None:
+            self.start_run()
+        ids = stand_ids or tuple(self._stands.keys())
+        for stand_id in ids:
+            self._run_stand(stand_id, years, checkpoint_interval)
+
+    def _run_stand(self, stand_id: str, years: float, checkpoint_interval: float | None) -> None:
+        record = self._require_stand(stand_id)
+        stand = record.stand
+        elapsed = 0.0
+        for module in record.modules:
+            stand_state = self.checkpointer.capture_stand_state(stand)
+            tree_states = self.checkpointer.capture_tree_states(stand)
+            model = module.instantiate()
+            module.validate_inputs(stand_state, tree_states, instance=model)
+            context = {"stand_id": stand_id, "manager": self}
+            model.initialize(context)
+            rng = (
+                self.seed_policy.generator(stand_id, module.name)
+                if self.seed_policy
+                else np.random.default_rng()
+            )
+            result = model.step(years, rng, stand_state, tree_states)
+            self._apply_model_result(stand, result)
+            model.finalize()
+            self._apply_rules(stand_id)
+            elapsed += module.time_step
+            if checkpoint_interval is None or elapsed >= checkpoint_interval:
+                self._record_checkpoint(stand_id, module)
+                elapsed = 0.0
+
+    def _apply_model_result(self, stand: Stand, result: ModelResult) -> None:
+        tree_lookup: Dict[str | int | None, Any] = {}
+        for plot in stand.plots:
+            for tree in plot.trees:
+                tree_lookup[tree.uid] = tree
+        for uid, deltas in (result.tree_deltas or {}).items():
+            tree = tree_lookup.get(uid)
+            if tree is None:
+                continue
+            for attr, delta in deltas.items():
+                current = getattr(tree, attr, None)
+                if current is None:
+                    setattr(tree, attr, delta)
+                else:
+                    setattr(tree, attr, current + delta)
+        for attr, delta in (result.stand_deltas or {}).items():
+            current = stand.attrs.get(attr)
+            if current is None:
+                stand.attrs[attr] = delta
+            else:
+                stand.attrs[attr] = current + delta
+        if result.metadata:
+            self._audit(f"Model metadata: {result.metadata}")
+        stand._metric_estimates.clear()
+
+    def _apply_rules(self, stand_id: str) -> None:
+        if not self._rulesets:
+            return
+        record = self._require_stand(stand_id)
+        stand = record.stand
+        state = self.checkpointer.capture_stand_state(stand)
+        for name, ruleset in self._rulesets.items():
+            decisions = ruleset.evaluate(self, stand_id, state, stand_tags=record.tags)
+            for decision in decisions:
+                self._audit(f"Ruleset {name} applied rule {decision.rule.name} to {stand_id}")
+
+    def _record_checkpoint(self, stand_id: str, module: GrowthModule) -> None:
+        stand = self._require_stand(stand_id).stand
+        checkpoint = self.checkpointer.create_checkpoint(
+            stand,
+            seed_state=self.seed_policy.snapshot() if self.seed_policy else {},
+            active_modules=[module.name],
+            pending_events=[dict(event) for event in self._pending_events.get(stand_id, ())],
+            metadata={"module": module.name, "time_step": module.time_step},
+        )
+        self._history[stand_id].append(checkpoint)
+
+    def _require_stand(self, stand_id: str) -> StandRecord:
+        if stand_id not in self._stands:
+            raise KeyError(f"Unknown stand '{stand_id}'")
+        return self._stands[stand_id]
+
+    def get_history(self, stand_id: str) -> Sequence[SimulationCheckpoint]:
+        return tuple(self._history.get(stand_id, ()))
+
+    def get_latest_checkpoint(self, stand_id: str) -> SimulationCheckpoint | None:
+        history = self._history.get(stand_id)
+        return history[-1] if history else None
+
+    def restore_from_checkpoint(self, stand_id: str, checkpoint: SimulationCheckpoint) -> None:
+        record = self._require_stand(stand_id)
+        self.checkpointer.restore(record.stand, checkpoint)
+        if self.seed_policy and checkpoint.seed_state:
+            self.seed_policy.restore(checkpoint.seed_state)
+        self._history[stand_id].append(checkpoint)
+        self._audit(f"Restored stand {stand_id} from checkpoint")
+
+    @property
+    def audit_log(self) -> Sequence[str]:
+        return tuple(self._audit_log)

--- a/src/pyforestry/simulation/rules.py
+++ b/src/pyforestry/simulation/rules.py
@@ -1,0 +1,95 @@
+"""Rule system enabling conditional actions on stands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Mapping, Sequence
+
+from .state import StandState
+
+__all__ = ["RuleAction", "Rule", "RuleSet", "RuleDecision"]
+
+
+@dataclass(slots=True)
+class RuleAction:
+    """Encapsulates an executable action triggered by a rule."""
+
+    name: str
+    callback: Callable[["SimulationManager", str, StandState], None]
+    metadata: Mapping[str, Any] | None = None
+
+    def execute(self, manager: "SimulationManager", stand_id: str, state: StandState) -> None:
+        self.callback(manager, stand_id, state)
+
+
+@dataclass(slots=True)
+class RuleDecision:
+    """Outcome of evaluating a rule."""
+
+    rule: "Rule"
+    actions_executed: Sequence[str]
+
+
+@dataclass(slots=True)
+class Rule:
+    """A predicate plus actions to run when it evaluates to ``True``."""
+
+    name: str
+    predicate: Callable[[StandState], bool]
+    actions: Sequence[RuleAction]
+    priority: int = 0
+    stop_on_match: bool = True
+
+    def applies(self, state: StandState) -> bool:
+        return self.predicate(state)
+
+
+@dataclass
+class RuleSet:
+    """Collection of rules with shared evaluation configuration."""
+
+    name: str
+    rules: Sequence[Rule]
+    scope: Mapping[str, Iterable[str]] | None = None
+    mode: str = "first"
+
+    def _sorted_rules(self) -> List[Rule]:
+        return sorted(self.rules, key=lambda rule: rule.priority, reverse=True)
+
+    def targets(self, stand_id: str, stand_tags: Iterable[str]) -> bool:
+        if not self.scope:
+            return True
+        explicit = set(self.scope.get("stands", ()))
+        tag_scope = set(self.scope.get("tags", ()))
+        if explicit and stand_id in explicit:
+            return True
+        if tag_scope and set(stand_tags) & tag_scope:
+            return True
+        return not explicit and not tag_scope
+
+    def evaluate(
+        self,
+        manager: "SimulationManager",
+        stand_id: str,
+        state: StandState,
+        stand_tags: Iterable[str] = (),
+    ) -> List[RuleDecision]:
+        if not self.targets(stand_id, stand_tags):
+            return []
+
+        decisions: List[RuleDecision] = []
+        for rule in self._sorted_rules():
+            if not rule.applies(state):
+                continue
+            executed: List[str] = []
+            for action in rule.actions:
+                action.execute(manager, stand_id, state)
+                executed.append(action.name)
+            decisions.append(RuleDecision(rule=rule, actions_executed=tuple(executed)))
+            if rule.stop_on_match or self.mode == "first":
+                break
+        return decisions
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .manager import SimulationManager

--- a/src/pyforestry/simulation/seeding.py
+++ b/src/pyforestry/simulation/seeding.py
@@ -1,0 +1,187 @@
+"""Deterministic seeding utilities for Monte Carlo simulations."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Tuple
+
+import numpy as np
+
+__all__ = [
+    "SeedPolicy",
+    "FixedSeedPolicy",
+    "PerModuleOffsetPolicy",
+    "RollingSeedPolicy",
+]
+
+
+def _stable_hash(*parts: str) -> int:
+    """Return a deterministic 64-bit hash for the provided parts."""
+
+    digest = hashlib.sha256("::".join(parts).encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big")
+
+
+def _key_to_str(key: Tuple[str, str]) -> str:
+    return f"{key[0]}::{key[1]}"
+
+
+def _str_to_key(value: str) -> Tuple[str, str]:
+    stand_id, module_name = value.split("::", 1)
+    return stand_id, module_name
+
+
+def _capture_state(generator: np.random.Generator) -> Mapping[str, Any]:
+    return generator.bit_generator.state
+
+
+def _restore_state(state: Mapping[str, Any]) -> np.random.Generator:
+    bit_name = state.get("bit_generator", "PCG64")
+    bit_cls = getattr(np.random, bit_name)
+    bit_gen = bit_cls()
+    bit_gen.state = state
+    return np.random.Generator(bit_gen)
+
+
+class SeedPolicy:
+    """Base class describing an RNG seeding strategy."""
+
+    def start_run(self) -> None:
+        """Initialise internal state before a simulation run begins."""
+
+    def generator(self, stand_id: str, module_name: str) -> np.random.Generator:
+        """Return a :class:`numpy.random.Generator` for the given module."""
+
+        raise NotImplementedError
+
+    def snapshot(self) -> Mapping[str, Any]:
+        """Return a serialisable description of the RNG state."""
+
+        raise NotImplementedError
+
+    def restore(self, payload: Mapping[str, Any]) -> None:
+        """Restore the policy state from :meth:`snapshot` output."""
+
+        raise NotImplementedError
+
+
+@dataclass
+class FixedSeedPolicy(SeedPolicy):
+    """Use a single seed for all modules and stands."""
+
+    seed: int
+    _generators: Dict[Tuple[str, str], np.random.Generator] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def start_run(self) -> None:  # noqa: D401 - see base class docstring
+        self._generators.clear()
+
+    def generator(self, stand_id: str, module_name: str) -> np.random.Generator:
+        key = (stand_id, module_name)
+        if key not in self._generators:
+            value = (self.seed + _stable_hash(stand_id, module_name)) % (2**32)
+            self._generators[key] = np.random.default_rng(value)
+        return self._generators[key]
+
+    def snapshot(self) -> Mapping[str, Any]:
+        return {
+            "seed": self.seed,
+            "streams": {_key_to_str(k): _capture_state(g) for k, g in self._generators.items()},
+        }
+
+    def restore(self, payload: Mapping[str, Any]) -> None:
+        self.seed = int(payload.get("seed", self.seed))
+        self.start_run()
+        for key_str, state in payload.get("streams", {}).items():
+            key = _str_to_key(key_str)
+            self._generators[key] = _restore_state(state)
+
+
+@dataclass
+class PerModuleOffsetPolicy(SeedPolicy):
+    """Base seed plus deterministic offsets for each module identifier."""
+
+    base_seed: int
+    offsets: Mapping[str, int]
+    _generators: Dict[Tuple[str, str], np.random.Generator] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def start_run(self) -> None:  # noqa: D401 - see base class docstring
+        self._generators.clear()
+
+    def generator(self, stand_id: str, module_name: str) -> np.random.Generator:
+        key = (stand_id, module_name)
+        if key not in self._generators:
+            offset = int(self.offsets.get(module_name, 0))
+            value = (self.base_seed + offset + _stable_hash(stand_id)) % (2**32)
+            self._generators[key] = np.random.default_rng(value)
+        return self._generators[key]
+
+    def snapshot(self) -> Mapping[str, Any]:
+        return {
+            "base_seed": self.base_seed,
+            "offsets": dict(self.offsets),
+            "streams": {_key_to_str(k): _capture_state(g) for k, g in self._generators.items()},
+        }
+
+    def restore(self, payload: Mapping[str, Any]) -> None:
+        self.base_seed = int(payload.get("base_seed", self.base_seed))
+        self.offsets = dict(payload.get("offsets", self.offsets))
+        self.start_run()
+        for key_str, state in payload.get("streams", {}).items():
+            key = _str_to_key(key_str)
+            self._generators[key] = _restore_state(state)
+
+
+@dataclass
+class RollingSeedPolicy(SeedPolicy):
+    """Assign sequential seeds to each module request while recording them."""
+
+    base_seed: int
+    _streams: Dict[Tuple[str, str], int] = field(default_factory=dict, init=False, repr=False)
+    _next_offset: int = field(default=0, init=False, repr=False)
+    _generators: Dict[Tuple[str, str], np.random.Generator] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def start_run(self) -> None:  # noqa: D401 - see base class docstring
+        self._streams.clear()
+        self._generators.clear()
+        self._next_offset = 0
+
+    def generator(self, stand_id: str, module_name: str) -> np.random.Generator:
+        key = (stand_id, module_name)
+        if key not in self._generators:
+            seed = (self.base_seed + self._next_offset) % (2**32)
+            self._streams[key] = seed
+            self._generators[key] = np.random.default_rng(seed)
+            self._next_offset += 1
+        return self._generators[key]
+
+    def snapshot(self) -> Mapping[str, Any]:
+        return {
+            "base_seed": self.base_seed,
+            "streams": {
+                _key_to_str(k): {"seed": seed, "state": _capture_state(self._generators[k])}
+                for k, seed in self._streams.items()
+            },
+            "next_offset": self._next_offset,
+        }
+
+    def restore(self, payload: Mapping[str, Any]) -> None:
+        self.base_seed = int(payload.get("base_seed", self.base_seed))
+        self._streams = {}
+        self._generators = {}
+        for key_str, data in payload.get("streams", {}).items():
+            key = _str_to_key(key_str)
+            seed = int(data.get("seed", self.base_seed))
+            state = data.get("state")
+            self._streams[key] = seed
+            if state is not None:
+                self._generators[key] = _restore_state(state)
+            else:
+                self._generators[key] = np.random.default_rng(seed)
+        self._next_offset = int(payload.get("next_offset", len(self._streams)))

--- a/src/pyforestry/simulation/state.py
+++ b/src/pyforestry/simulation/state.py
@@ -1,0 +1,97 @@
+"""Immutable snapshot models used by the simulation framework."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence, Tuple
+
+
+@dataclass(frozen=True, slots=True)
+class TreeState:
+    """An immutable representation of the state of a :class:`Tree` instance.
+
+    The dataclass deliberately mirrors the attributes exposed by
+    :class:`pyforestry.base.helpers.tree.Tree` while remaining serialisable.
+    Only plain Python types are stored so that ``TreeState`` objects can be
+    included in checkpoint payloads or JSON documents without custom
+    encoders.
+    """
+
+    uid: str | int | None
+    """Unique identifier assigned to the originating tree (if provided)."""
+
+    species: str | None
+    """Species name captured using ``TreeName.full_name`` where available."""
+
+    age: float | None
+    """Tree age in years."""
+
+    diameter_cm: float | None
+    """Diameter at breast height in centimetres."""
+
+    height_m: float | None
+    """Total height in metres."""
+
+    weight_n: float
+    """Number of represented stems."""
+
+    position: Tuple[float, ...] | None
+    """Cartesian coordinates of the tree, stored as an ``(x, y[, z])`` tuple."""
+
+    plot_id: str | int | None
+    """Identifier of the :class:`~pyforestry.base.helpers.plot.CircularPlot`."""
+
+    deltas: Mapping[str, float] = field(default_factory=dict)
+    """Optional growth deltas recorded by models for diagnostics."""
+
+    extras: Mapping[str, Any] = field(default_factory=dict)
+    """Additional per-model variables preserved for later analysis."""
+
+
+@dataclass(frozen=True, slots=True)
+class PlotState:
+    """Snapshot of a plot used to derive tree contexts when restoring."""
+
+    id: str | int
+    area_m2: float | None
+    radius_m: float | None
+    occlusion: float
+    position: Tuple[float, ...] | None
+    site: Any
+    tree_uids: Tuple[str | int | None, ...]
+    angle_counts: Tuple[Any, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class StandState:
+    """Aggregated representation of a :class:`Stand` and its plots."""
+
+    site: Any
+    area_ha: float | None
+    top_height_definition: Any
+    attrs: Mapping[str, Any]
+    metric_estimates: Mapping[str, Mapping[str, float]]
+    use_angle_count: bool
+    plots: Tuple[PlotState, ...] = field(default_factory=tuple)
+
+    def require_metric(self, metric: str) -> Mapping[str, float]:
+        """Retrieve a metric from the cached estimates.
+
+        Parameters
+        ----------
+        metric:
+            Name of the metric to extract.
+
+        Returns
+        -------
+        Mapping[str, float]
+            Mapping of species (or ``"TOTAL"``) to numeric values.
+        """
+
+        if metric not in self.metric_estimates:
+            raise KeyError(f"Metric '{metric}' missing from stand snapshot")
+        return self.metric_estimates[metric]
+
+
+TreeStateSequence = Sequence[TreeState]
+"""Convenience alias used by other simulation components."""

--- a/tests/simulation/test_checkpoint.py
+++ b/tests/simulation/test_checkpoint.py
@@ -1,0 +1,65 @@
+"""Tests for simulation checkpoint primitives."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from pyforestry.base.helpers import CircularPlot, Stand, Tree
+from pyforestry.base.helpers.primitives.cartesian_position import Position
+from pyforestry.simulation.checkpoint import SimulationCheckpoint, TreeCheckpointer
+
+
+@pytest.fixture
+def sample_stand() -> Stand:
+    trees = [
+        Tree(uid="t1", species="picea abies", diameter_cm=30.0, height_m=18.0, age=40.0),
+        Tree(uid="t2", species="pinus sylvestris", diameter_cm=25.0, height_m=15.0, age=35.0),
+    ]
+    plot = CircularPlot(id="p1", radius_m=5.0, position=Position(0, 0), trees=trees)
+    stand = Stand(area_ha=1.0, plots=[plot])
+    return stand
+
+
+def test_tree_state_capture_contains_expected_fields(sample_stand: Stand) -> None:
+    checkpointer = TreeCheckpointer()
+    tree_states = checkpointer.capture_tree_states(sample_stand)
+    assert len(tree_states) == 2
+    first = tree_states[0]
+    assert first.uid == "t1"
+    assert first.diameter_cm == pytest.approx(30.0)
+    assert first.plot_id == "p1"
+
+
+def test_checkpoint_roundtrip_restores_metrics(sample_stand: Stand) -> None:
+    checkpointer = TreeCheckpointer()
+    baseline = checkpointer.create_checkpoint(
+        sample_stand,
+        seed_state={"seed": 7},
+        active_modules=["dummy"],
+        timestamp=datetime(2024, 1, 1),
+    )
+    original_basal_area = float(sample_stand.BasalArea)
+
+    new_tree = Tree(uid="t3", species="picea abies", diameter_cm=20.0, height_m=12.0)
+    new_plot = CircularPlot(id="p2", radius_m=4.0, position=Position(10, 0), trees=[new_tree])
+    sample_stand.append_plot(new_plot)
+    sample_stand.thin_trees(uids=["t1"])
+
+    checkpointer.restore(sample_stand, baseline)
+
+    assert len(sample_stand.plots) == 1
+    restored_tree_uids = {tree.uid for plot in sample_stand.plots for tree in plot.trees}
+    assert restored_tree_uids == {"t1", "t2"}
+    assert float(sample_stand.BasalArea) == pytest.approx(original_basal_area)
+
+
+def test_checkpoint_serialisation_roundtrip(sample_stand: Stand) -> None:
+    checkpointer = TreeCheckpointer()
+    checkpoint = checkpointer.create_checkpoint(sample_stand, seed_state={"seed": 99})
+    payload = checkpoint.to_dict()
+    rebuilt = SimulationCheckpoint.from_dict(payload)
+    assert rebuilt.seed_state["seed"] == 99
+    assert len(rebuilt.tree_states) == len(checkpoint.tree_states)
+    assert rebuilt.stand_state.area_ha == pytest.approx(sample_stand.area_ha)

--- a/tests/simulation/test_growth_module.py
+++ b/tests/simulation/test_growth_module.py
@@ -1,0 +1,105 @@
+"""Tests covering the growth model protocol and module factory."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyforestry.simulation.growth import GrowthModule, ModelResult
+from pyforestry.simulation.state import StandState, TreeState
+
+
+class DummyTreeModel:
+    level = "tree"
+    time_step = 0.5
+    requires_checkpoint = False
+    required_tree_fields = ("diameter_cm",)
+    required_stand_fields = ("area_ha",)
+
+    def __init__(self, factor: float = 1.0) -> None:
+        self.factor = factor
+        self.initialised = False
+
+    def validate_inputs(self, stand_state: StandState, tree_states) -> None:  # noqa: D401
+        assert stand_state.area_ha is not None
+        for tree in tree_states:
+            assert tree.diameter_cm is not None
+
+    def initialize(self, context=None) -> None:  # noqa: D401
+        self.initialised = True
+
+    def step(self, years, rng, stand_state, tree_states):  # noqa: D401
+        assert self.initialised
+        increments = {tree.uid: {"diameter_cm": self.factor * years} for tree in tree_states}
+        return ModelResult(tree_deltas=increments)
+
+    def finalize(self) -> None:  # noqa: D401
+        self.initialised = False
+
+
+def build_tree_state(value: float) -> TreeState:
+    return TreeState(
+        uid="tree-1",
+        species="picea abies",
+        age=10.0,
+        diameter_cm=value,
+        height_m=15.0,
+        weight_n=1.0,
+        position=(0.0, 0.0),
+        plot_id="plot-1",
+    )
+
+
+def build_stand_state() -> StandState:
+    return StandState(
+        site=None,
+        area_ha=1.0,
+        top_height_definition=None,
+        attrs={},
+        metric_estimates={"BasalArea": {"TOTAL": 20.0}},
+        use_angle_count=False,
+        plots=(),
+    )
+
+
+def test_growth_module_metadata_and_schema() -> None:
+    module = GrowthModule(DummyTreeModel, config={"factor": 2.0})
+    meta = module.metadata()
+    assert meta["level"] == "tree"
+    assert meta["time_step"] == pytest.approx(0.5)
+    schema = module.schema()
+    assert "factor" in schema
+
+
+def test_growth_module_validates_required_fields() -> None:
+    module = GrowthModule(DummyTreeModel)
+    stand_state = build_stand_state()
+    tree_states = [build_tree_state(25.0)]
+    instance = module.instantiate()
+    module.validate_inputs(stand_state, tree_states, instance=instance)
+    instance.initialize({})
+    result = instance.step(1.0, np.random.default_rng(1), stand_state, tree_states)
+    assert result.tree_deltas["tree-1"]["diameter_cm"] == pytest.approx(1.0)
+
+
+def test_growth_module_rejects_missing_fields() -> None:
+    module = GrowthModule(DummyTreeModel)
+    stand_state = build_stand_state()
+    invalid_tree = TreeState(
+        uid="tree-1",
+        species="picea abies",
+        age=10.0,
+        diameter_cm=None,
+        height_m=15.0,
+        weight_n=1.0,
+        position=(0.0, 0.0),
+        plot_id="plot-1",
+    )
+    instance = module.instantiate()
+    with pytest.raises(ValueError):
+        module.validate_inputs(stand_state, [invalid_tree], instance=instance)
+
+
+def test_growth_module_rejects_unknown_config_keys() -> None:
+    with pytest.raises(TypeError):
+        GrowthModule(DummyTreeModel, config={"unknown": 1})

--- a/tests/simulation/test_manager.py
+++ b/tests/simulation/test_manager.py
@@ -1,0 +1,105 @@
+"""Integration tests for the simulation manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pyforestry.base.helpers import CircularPlot, Stand, Tree
+from pyforestry.base.helpers.primitives.cartesian_position import Position
+from pyforestry.simulation import (
+    FixedSeedPolicy,
+    GrowthModule,
+    ModelResult,
+    Rule,
+    RuleAction,
+    RuleSet,
+    SimulationManager,
+    StandState,
+)
+
+
+class IncrementAgeModel:
+    level = "tree"
+    time_step = 1.0
+    requires_checkpoint = False
+    required_tree_fields = ("age",)
+    required_stand_fields = ()
+
+    def __init__(self, increment: float = 1.0) -> None:
+        self.increment = increment
+        self.initialised = False
+
+    def validate_inputs(self, stand_state: StandState, tree_states) -> None:  # noqa: D401
+        for tree in tree_states:
+            assert tree.age is not None
+
+    def initialize(self, context: dict[str, Any] | None = None) -> None:  # noqa: D401
+        self.initialised = True
+
+    def step(self, years, rng, stand_state, tree_states):  # noqa: D401
+        assert self.initialised
+        deltas = {tree.uid: {"age": self.increment * years} for tree in tree_states}
+        stand_delta = {"years_simulated": years}
+        return ModelResult(tree_deltas=deltas, stand_deltas=stand_delta)
+
+    def finalize(self) -> None:  # noqa: D401
+        self.initialised = False
+
+
+@pytest.fixture
+def simple_stand() -> Stand:
+    tree = Tree(uid="t1", species="picea abies", age=10.0, diameter_cm=30.0, height_m=18.0)
+    plot = CircularPlot(id="p1", radius_m=5.0, position=Position(0, 0), trees=[tree])
+    return Stand(area_ha=1.0, plots=[plot])
+
+
+def test_manager_runs_modules_and_updates_state(simple_stand: Stand) -> None:
+    module = GrowthModule(IncrementAgeModel, config={"increment": 2.0})
+    manager = SimulationManager(seed_policy=FixedSeedPolicy(42))
+    manager.register_stand("stand-1", simple_stand, modules=[module])
+    manager.start_run()
+    manager.run(years=1.0, stand_ids=["stand-1"])
+
+    tree = simple_stand.plots[0].trees[0]
+    assert tree.age == pytest.approx(12.0)
+    assert simple_stand.attrs["years_simulated"] == pytest.approx(1.0)
+    history = manager.get_history("stand-1")
+    assert len(history) >= 2
+    checkpoint = manager.get_latest_checkpoint("stand-1")
+    assert checkpoint is not None
+    assert checkpoint.metadata["module"] == module.name
+
+    tree.age = 0.0
+    manager.restore_from_checkpoint("stand-1", checkpoint)
+    assert simple_stand.plots[0].trees[0].age == pytest.approx(12.0)
+
+
+def test_manager_applies_rules(simple_stand: Stand) -> None:
+    module = GrowthModule(IncrementAgeModel)
+    manager = SimulationManager(seed_policy=FixedSeedPolicy(12))
+    manager.register_stand("stand-2", simple_stand, modules=[module], tags=["managed"])
+
+    def predicate(state: StandState) -> bool:
+        stems = state.metric_estimates["Stems"]["TOTAL"]
+        return stems >= 1
+
+    def thin_first(manager: SimulationManager, stand_id: str, state: StandState) -> None:
+        record = manager._require_stand(stand_id)  # noqa: SLF001 - test helper usage
+        first_uid = state.plots[0].tree_uids[0]
+        record.stand.thin_trees(uids=[first_uid])
+
+    rule = Rule(
+        name="thin-first",
+        predicate=predicate,
+        actions=[RuleAction(name="thin", callback=thin_first)],
+    )
+    manager.register_ruleset(
+        "default", RuleSet(name="rs", rules=[rule], scope={"tags": ["managed"]})
+    )
+
+    manager.start_run()
+    manager.run(years=1.0, stand_ids=["stand-2"])
+
+    assert len(simple_stand.plots[0].trees) == 0

--- a/tests/simulation/test_rules.py
+++ b/tests/simulation/test_rules.py
@@ -1,0 +1,67 @@
+"""Unit tests for the rule engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from pyforestry.simulation.rules import Rule, RuleAction, RuleDecision, RuleSet
+from pyforestry.simulation.state import PlotState, StandState
+
+
+@dataclass
+class StubManager:
+    calls: List[str]
+
+
+def build_state() -> StandState:
+    plot = PlotState(
+        id="p1",
+        area_m2=100.0,
+        radius_m=5.0,
+        occlusion=0.0,
+        position=(0.0, 0.0),
+        site=None,
+        tree_uids=("t1", "t2"),
+    )
+    return StandState(
+        site=None,
+        area_ha=1.0,
+        top_height_definition=None,
+        attrs={"management": "baseline"},
+        metric_estimates={"Stems": {"TOTAL": 2}},
+        use_angle_count=False,
+        plots=(plot,),
+    )
+
+
+def test_ruleset_executes_first_matching_rule() -> None:
+    manager = StubManager(calls=[])
+    action = RuleAction(
+        name="record",
+        callback=lambda mgr, stand_id, state: mgr.calls.append(stand_id),
+    )
+    rule = Rule(name="apply", predicate=lambda s: True, actions=[action], priority=10)
+    ruleset = RuleSet(name="rs", rules=[rule], scope={"stands": ["stand-A"]})
+
+    decisions = ruleset.evaluate(manager, "stand-A", build_state())
+
+    assert decisions == [RuleDecision(rule=rule, actions_executed=("record",))]
+    assert manager.calls == ["stand-A"]
+
+
+def test_ruleset_respects_scope_tags() -> None:
+    manager = StubManager(calls=[])
+    action = RuleAction(
+        name="record",
+        callback=lambda mgr, stand_id, state: mgr.calls.append(stand_id),
+    )
+    rule = Rule(name="tagged", predicate=lambda s: True, actions=[action])
+    ruleset = RuleSet(name="rs", rules=[rule], scope={"tags": ["priority"]})
+
+    assert ruleset.evaluate(manager, "stand-B", build_state(), stand_tags=["priority"])
+    assert manager.calls == ["stand-B"]
+
+    manager.calls.clear()
+    assert ruleset.evaluate(manager, "stand-C", build_state(), stand_tags=["other"]) == []
+    assert manager.calls == []

--- a/tests/simulation/test_seeding.py
+++ b/tests/simulation/test_seeding.py
@@ -1,0 +1,51 @@
+"""Regression tests for seed policy utilities."""
+
+from __future__ import annotations
+
+from pyforestry.simulation.seeding import (
+    FixedSeedPolicy,
+    PerModuleOffsetPolicy,
+    RollingSeedPolicy,
+)
+
+
+def test_fixed_seed_policy_restores_state() -> None:
+    policy = FixedSeedPolicy(123)
+    policy.start_run()
+    rng = policy.generator("stand", "module")
+    rng.integers(0, 1000)
+    snapshot = policy.snapshot()
+    second = rng.integers(0, 1000)
+
+    clone = FixedSeedPolicy(0)
+    clone.restore(snapshot)
+    restored_rng = clone.generator("stand", "module")
+    assert restored_rng.integers(0, 1000) == second
+
+
+def test_per_module_offset_policy_distinguishes_modules() -> None:
+    policy = PerModuleOffsetPolicy(base_seed=10, offsets={"A": 1, "B": 99})
+    policy.start_run()
+    rng_a = policy.generator("stand", "A")
+    rng_b = policy.generator("stand", "B")
+    snapshot = policy.snapshot()
+    assert snapshot["streams"]["stand::A"] != snapshot["streams"]["stand::B"]
+    assert rng_a.integers(0, 10_000) != rng_b.integers(0, 10_000)
+
+
+def test_rolling_seed_policy_snapshot_and_restore() -> None:
+    policy = RollingSeedPolicy(5)
+    policy.start_run()
+    rng1 = policy.generator("stand", "M1")
+    rng1.integers(0, 10_000)
+    snapshot = policy.snapshot()
+    next_value = rng1.integers(0, 10_000)
+    rng2 = policy.generator("stand", "M2")
+    second_value = rng2.integers(0, 10_000)
+
+    restored = RollingSeedPolicy(0)
+    restored.restore(snapshot)
+    restored_rng1 = restored.generator("stand", "M1")
+    assert restored_rng1.integers(0, 10_000) == next_value
+    restored_rng2 = restored.generator("stand", "M2")
+    assert restored_rng2.integers(0, 10_000) == second_value


### PR DESCRIPTION
## Summary
- add simulation state, checkpointing, growth module protocol, a simulation manager, rules, and seed policy utilities
- document the simulation API and rules engine and expose the new pages in the docs toctree
- exercise the new components with tests covering checkpointing, growth module validation, manager orchestration, rules, and seeding

## Testing
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50


------
https://chatgpt.com/codex/tasks/task_e_68e9203c8ae48329a684d872c95d5ba7