### PR TITLE
Add simulation model view adapters

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -37,6 +37,23 @@ consume. Combined, they provide a baseline vocabulary for describing spatial
 forest inventories, handling unit conversions, and validating data before it is
 passed into model pipelines.
 
+Simulation model views
+----------------------
+
+The :mod:`pyforestry.simulation` package now ships ``ModelView`` building
+blocks that map directly onto the helper layer. ``StandMetricView`` adapts a
+:class:`~pyforestry.base.helpers.stand.Stand` so that consumers can query
+``BasalArea``, ``Stems`` and related accessors without needing to know the
+implementation details of :class:`~pyforestry.base.helpers.stand.StandMetricAccessor`.
+``InventoryView`` exposes a lightweight iterator façade over the stand's
+:class:`~pyforestry.base.helpers.plot.CircularPlot` collection while
+``SpatialTreeView`` focuses on the positional attributes carried by individual
+:class:`~pyforestry.base.helpers.tree.Tree` instances.
+
+These views provide the first bridge into the future simulation pipeline: they
+package the rich helper data into read-only façades that the forthcoming
+``SimulationManager`` can consume when orchestrating full scenario runs.
+
 Future simulation architecture
 ------------------------------
 

--- a/src/pyforestry/__init__.py
+++ b/src/pyforestry/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for pyforestry."""
 
-from . import base, sweden
+from . import base, simulation, sweden
 
-__all__ = ["base", "sweden"]
+__all__ = ["base", "simulation", "sweden"]

--- a/src/pyforestry/simulation/__init__.py
+++ b/src/pyforestry/simulation/__init__.py
@@ -1,0 +1,9 @@
+"""Simulation-facing views that expose helper-layer data."""
+
+from .model_view import InventoryView, SpatialTreeView, StandMetricView
+
+__all__ = [
+    "InventoryView",
+    "SpatialTreeView",
+    "StandMetricView",
+]

--- a/src/pyforestry/simulation/model_view.py
+++ b/src/pyforestry/simulation/model_view.py
@@ -1,0 +1,194 @@
+"""View classes that bridge helper-layer objects into the simulation API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Tuple, Union
+
+from pyforestry.base.helpers import CircularPlot, Stand, StandMetricAccessor, Tree
+from pyforestry.base.helpers.primitives import Position
+from pyforestry.base.helpers.tree_species import TreeName, parse_tree_species
+
+
+class StandMetricView:
+    """Expose stand-level aggregations via :class:`StandMetricAccessor` objects."""
+
+    _SUPPORTED = ("BasalArea", "Stems", "QMD", "BAWAD")
+
+    def __init__(self, stand: Stand):
+        if not isinstance(stand, Stand):  # pragma: no cover - defensive
+            raise TypeError("StandMetricView requires a Stand instance.")
+        if not stand.plots:
+            raise ValueError("StandMetricView requires a stand with at least one plot.")
+        for plot in stand.plots:
+            if not isinstance(plot, CircularPlot):
+                raise TypeError("StandMetricView expects plots to be CircularPlot instances.")
+        self._stand = stand
+
+    @property
+    def requires_stand_metrics(self) -> bool:
+        """Flag indicating that stand-level metric estimates are required."""
+
+        return True
+
+    @property
+    def requires_plots(self) -> bool:
+        """Stand metrics ultimately derive from the stand's plots."""
+
+        return True
+
+    @property
+    def requires_trees(self) -> bool:
+        """Whether tree-level observations are needed to source the metrics."""
+
+        return not self._stand.use_angle_count
+
+    @property
+    def supported_metrics(self) -> Tuple[str, ...]:
+        """Return the list of metric accessors this view can expose."""
+
+        available = []
+        for name in self._SUPPORTED:
+            if hasattr(self._stand.__class__, name):
+                available.append(name)
+        return tuple(available)
+
+    def metric(self, metric_name: str) -> StandMetricAccessor:
+        """Return the :class:`StandMetricAccessor` for ``metric_name``."""
+
+        if metric_name not in self.supported_metrics:
+            raise KeyError(f"Stand does not expose a {metric_name} accessor.")
+        accessor = getattr(self._stand, metric_name)
+        if not isinstance(accessor, StandMetricAccessor):  # pragma: no cover - defensive
+            raise TypeError(f"Stand attribute {metric_name} is not a StandMetricAccessor.")
+        return accessor
+
+    def total(self, metric_name: str) -> float:
+        """Return the total value for the supplied metric."""
+
+        return float(self.metric(metric_name))
+
+    def by_species(self, metric_name: str, species: Union[TreeName, str]):
+        """Delegate species-level lookups to the matching accessor."""
+
+        return self.metric(metric_name)(species)
+
+
+@dataclass
+class InventoryView:
+    """Iterate over the plots and trees that compose a stand inventory."""
+
+    stand: Stand
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.stand, Stand):  # pragma: no cover - defensive
+            raise TypeError("InventoryView requires a Stand instance.")
+        if not self.stand.plots:
+            raise ValueError("InventoryView requires at least one CircularPlot.")
+        for plot in self.stand.plots:
+            if not isinstance(plot, CircularPlot):
+                raise TypeError("InventoryView expects CircularPlot instances.")
+            if plot.trees is None:
+                raise ValueError("InventoryView requires plots to expose tree collections.")
+        self._plots = tuple(self.stand.plots)
+
+    @property
+    def requires_stand_metrics(self) -> bool:
+        """Inventory iteration does not demand pre-computed stand metrics."""
+
+        return False
+
+    @property
+    def requires_plots(self) -> bool:
+        """The view iterates plots directly."""
+
+        return True
+
+    @property
+    def requires_trees(self) -> bool:
+        """Determine whether any plots expose tree measurements."""
+
+        return any(plot.trees for plot in self._plots)
+
+    @property
+    def plot_count(self) -> int:
+        """Number of plots available in the inventory."""
+
+        return len(self._plots)
+
+    def iter_plots(self) -> Iterator[CircularPlot]:
+        """Yield plots exactly as stored on the underlying :class:`Stand`."""
+
+        for plot in self._plots:
+            yield plot
+
+    def iter_trees(self) -> Iterator[Tree]:
+        """Yield trees from every plot in inventory order."""
+
+        for plot in self._plots:
+            for tree in plot.trees:
+                yield tree
+
+
+@dataclass
+class SpatialTreeView:
+    """Expose the spatial context of an individual :class:`Tree`."""
+
+    tree: Tree
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.tree, Tree):  # pragma: no cover - defensive
+            raise TypeError("SpatialTreeView requires a Tree instance.")
+        if not isinstance(self.tree.position, Position):
+            raise ValueError("SpatialTreeView requires trees to carry a Position.")
+        if self.tree.weight_n is None or self.tree.weight_n <= 0:
+            raise ValueError("SpatialTreeView requires tree weights to be positive.")
+
+    @property
+    def requires_stand_metrics(self) -> bool:
+        """Spatial views operate solely on tree-level inputs."""
+
+        return False
+
+    @property
+    def requires_plots(self) -> bool:
+        """No plot context is necessary to expose tree coordinates."""
+
+        return False
+
+    @property
+    def requires_trees(self) -> bool:
+        """The view is defined for tree measurements."""
+
+        return True
+
+    @property
+    def requires_spatial_coordinates(self) -> bool:
+        """Spatial outputs mandate positional data."""
+
+        return True
+
+    @property
+    def coordinates(self) -> Tuple[float, float, float]:
+        """Return the tree coordinates as an ``(x, y, z)`` tuple."""
+
+        pos = self.tree.position
+        assert isinstance(pos, Position)  # mypy/runtime guard
+        return (pos.X, pos.Y, pos.Z or 0.0)
+
+    @property
+    def species(self) -> Union[TreeName, None]:
+        """Return the tree's species identifier if available."""
+
+        raw_species = self.tree.species
+        if raw_species is None:
+            return None
+        if isinstance(raw_species, str):
+            return parse_tree_species(raw_species)
+        return raw_species
+
+    @property
+    def weight(self) -> float:
+        """Return the expansion factor associated with the tree."""
+
+        return float(self.tree.weight_n)

--- a/tests/simulation/test_model_view.py
+++ b/tests/simulation/test_model_view.py
@@ -1,0 +1,110 @@
+"""Tests for the simulation-facing model view abstractions."""
+
+import math
+
+import pytest
+
+from pyforestry.base.helpers import CircularPlot, Stand, Tree
+from pyforestry.base.helpers.primitives import Position
+from pyforestry.base.helpers.tree_species import parse_tree_species
+from pyforestry.simulation import InventoryView, SpatialTreeView, StandMetricView
+
+
+@pytest.fixture
+def demo_stand():
+    """Provide a stand with two plots and mixed-species trees for testing."""
+
+    sp_picea = parse_tree_species("picea abies")
+    sp_pinus = parse_tree_species("pinus sylvestris")
+
+    plot_one = CircularPlot(
+        id=1,
+        radius_m=5.0,
+        trees=[
+            Tree(position=Position(10, 10), species=sp_picea, diameter_cm=25, weight_n=2),
+            Tree(position=Position(11, 10), species=sp_pinus, diameter_cm=30, weight_n=1),
+        ],
+    )
+    plot_two = CircularPlot(
+        id=2,
+        radius_m=5.0,
+        trees=[
+            Tree(position=Position(20, 20), species=sp_picea, diameter_cm=20, weight_n=1),
+            Tree(position=Position(21, 20), species=sp_pinus, diameter_cm=35, weight_n=2),
+        ],
+    )
+    return Stand(plots=[plot_one, plot_two])
+
+
+def test_stand_metric_view_delegates_accessors(demo_stand):
+    """StandMetricView should mirror Stand metric accessors and totals."""
+
+    view = StandMetricView(demo_stand)
+
+    assert view.requires_stand_metrics is True
+    assert view.requires_plots is True
+    assert view.requires_trees is True
+    assert "BasalArea" in view.supported_metrics
+
+    ba_accessor = view.metric("BasalArea")
+    assert math.isclose(float(ba_accessor), float(demo_stand.BasalArea))
+
+    stems_species = view.by_species("Stems", "picea abies")
+    assert math.isclose(stems_species.value, demo_stand.Stems("picea abies").value)
+
+    with pytest.raises(KeyError):
+        view.metric("NotAMetric")
+
+
+def test_stand_metric_view_rejects_empty_stand():
+    """A stand without plots cannot be adapted to StandMetricView."""
+
+    with pytest.raises(ValueError):
+        StandMetricView(Stand(plots=[]))
+
+
+def test_inventory_view_iteration(demo_stand):
+    """InventoryView should iterate plots and trees in declaration order."""
+
+    view = InventoryView(demo_stand)
+
+    assert view.requires_stand_metrics is False
+    assert view.requires_plots is True
+    assert view.requires_trees is True
+    assert view.plot_count == len(demo_stand.plots)
+
+    assert list(view.iter_plots()) == demo_stand.plots
+
+    expected_trees = [tree for plot in demo_stand.plots for tree in plot.trees]
+    assert list(view.iter_trees()) == expected_trees
+
+
+def test_inventory_view_requires_plots():
+    """InventoryView should reject stands without circular plots."""
+
+    with pytest.raises(ValueError):
+        InventoryView(Stand(plots=[]))
+
+
+def test_spatial_tree_view_coordinates():
+    """SpatialTreeView should expose position, species and weight metadata."""
+
+    tree = Tree(position=Position(100.0, 200.0, 10.0), species="picea abies", weight_n=3)
+    view = SpatialTreeView(tree)
+
+    assert view.requires_stand_metrics is False
+    assert view.requires_plots is False
+    assert view.requires_trees is True
+    assert view.requires_spatial_coordinates is True
+
+    assert view.coordinates == (100.0, 200.0, 10.0)
+    assert view.species.full_name == "picea abies"
+    assert math.isclose(view.weight, 3.0)
+
+
+def test_spatial_tree_view_requires_position():
+    """Trees without spatial positions should be rejected by the view."""
+
+    tree = Tree(species="picea abies", weight_n=1.0)
+    with pytest.raises(ValueError):
+        SpatialTreeView(tree)


### PR DESCRIPTION
## Summary
- add StandMetricView, InventoryView, and SpatialTreeView adapters that validate helper inputs and expose capability flags
- surface the simulation module in the public package and document how the views align with the planned pipeline
- cover the new adapters with targeted unit tests exercising metrics, iteration, and spatial data handling

## Testing
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50

------
https://chatgpt.com/codex/tasks/task_e_68ea5482bb048329b48058d6d2e14e8c