### PR TITLE
Add stand composite coordination helpers

### DIFF
--- a/src/pyforestry/simulation/__init__.py
+++ b/src/pyforestry/simulation/__init__.py
@@ -1,9 +1,21 @@
 """Simulation-facing views that expose helper-layer data."""
 
 from .model_view import InventoryView, SpatialTreeView, StandMetricView
+from .stand_composite import (
+    DispatchRecord,
+    DispatchResult,
+    StandAction,
+    StandComposite,
+    StandPart,
+)
 
 __all__ = [
     "InventoryView",
     "SpatialTreeView",
     "StandMetricView",
+    "DispatchRecord",
+    "DispatchResult",
+    "StandAction",
+    "StandComposite",
+    "StandPart",
 ]

--- a/src/pyforestry/simulation/stand_composite.py
+++ b/src/pyforestry/simulation/stand_composite.py
@@ -1,0 +1,316 @@
+"""Composite helpers for coordinating multi-part stand simulations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+MetricSource = Union[str, Iterable[str], None]
+PolicySelector = Union[
+    str,
+    Callable[["StandAction", Tuple["StandPart", ...]], Sequence["StandPart"]],
+]
+
+
+def _call_or_value(value: Any) -> Any:
+    """Return ``value`` or call it if it is callable."""
+
+    if callable(value):
+        return value()
+    return value
+
+
+@dataclass
+class StandAction:
+    """Represent an action that can be dispatched to one or more stand parts."""
+
+    name: str
+    handler: Callable[["StandPart"], Any]
+    cost: Union[float, Callable[["StandPart"], float]] = 0.0
+    harvest: Union[float, Callable[["StandPart"], float]] = 0.0
+    target_parts: MetricSource = None
+
+    def cost_for(self, part: "StandPart") -> float:
+        """Resolve the cost for ``part``."""
+
+        cost = self.cost(part) if callable(self.cost) else self.cost
+        return float(cost)
+
+    def harvest_for(self, part: "StandPart") -> float:
+        """Resolve the harvested volume for ``part``."""
+
+        harvest = self.harvest(part) if callable(self.harvest) else self.harvest
+        return float(harvest)
+
+    def execute(self, part: "StandPart") -> Any:
+        """Execute the underlying handler for ``part``."""
+
+        return self.handler(part)
+
+    def iter_targets(self) -> Tuple[str, ...]:
+        """Return a normalized tuple of target part identifiers."""
+
+        if self.target_parts is None:
+            return ()
+        if isinstance(self.target_parts, str):
+            return (self.target_parts,)
+        return tuple(self.target_parts)
+
+
+@dataclass
+class DispatchRecord:
+    """Track the result of sending an action to a specific stand part."""
+
+    part: str
+    action: str
+    cost: float
+    harvest: float
+    result: Any
+
+
+@dataclass
+class DispatchResult:
+    """Aggregate the outcome of a dispatch cycle."""
+
+    records: List[DispatchRecord] = field(default_factory=list)
+
+    @property
+    def spent(self) -> float:
+        """Return the total spend incurred by the dispatch."""
+
+        return float(sum(record.cost for record in self.records))
+
+    @property
+    def harvested(self) -> float:
+        """Return the total harvested amount incurred by the dispatch."""
+
+        return float(sum(record.harvest for record in self.records))
+
+    def by_part(self) -> Dict[str, List[DispatchRecord]]:
+        """Group dispatch records by part identifier."""
+
+        grouped: Dict[str, List[DispatchRecord]] = {}
+        for record in self.records:
+            grouped.setdefault(record.part, []).append(record)
+        return grouped
+
+
+@dataclass
+class StandPart:
+    """Container binding a model view, context and override parameters."""
+
+    name: str
+    model_view: Any
+    context: Mapping[str, Any] = field(default_factory=dict)
+    growth_overrides: Optional[Mapping[str, Any]] = None
+    disturbance_overrides: Optional[Mapping[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Stand parts require a non-empty name.")
+        if not isinstance(self.context, Mapping):
+            raise TypeError("Context must implement the mapping protocol.")
+        self.context = dict(self.context)
+        self.growth_overrides = dict(self.growth_overrides or {})
+        self.disturbance_overrides = dict(self.disturbance_overrides or {})
+
+    def _metric_from_model(self, attr_name: str, metric_name: str, default: float) -> float:
+        """Attempt to resolve ``metric_name`` from the attached model view."""
+
+        view = self.model_view
+
+        if hasattr(view, attr_name):
+            value = getattr(view, attr_name)
+            try:
+                return float(_call_or_value(value))
+            except TypeError:
+                pass
+        if hasattr(view, metric_name):
+            metric_value = getattr(view, metric_name)
+            try:
+                return float(_call_or_value(metric_value))
+            except TypeError:
+                pass
+        total_method = getattr(view, "total", None)
+        if callable(total_method):
+            try:
+                return float(total_method(metric_name))
+            except (KeyError, TypeError):
+                pass
+        context_value = None
+        if isinstance(self.context, Mapping):
+            context_value = self.context.get(attr_name, default)
+        return float(context_value if context_value is not None else default)
+
+    @property
+    def basal_area(self) -> float:
+        """Basal area contributed by this part."""
+
+        return self._metric_from_model("basal_area", "BasalArea", 0.0)
+
+    @property
+    def stems(self) -> float:
+        """Stem count contributed by this part."""
+
+        return self._metric_from_model("stems", "Stems", 0.0)
+
+    @property
+    def cash(self) -> float:
+        """Cash contribution for this part."""
+
+        return self._metric_from_model("cash", "Cash", 0.0)
+
+    @property
+    def growth_parameters(self) -> Mapping[str, Any]:
+        """Return the resolved growth parameters for the part."""
+
+        base: MutableMapping[str, Any] = dict(self.context.get("growth", {}))
+        base.update(self.growth_overrides)
+        return dict(base)
+
+    @property
+    def disturbance_parameters(self) -> Mapping[str, Any]:
+        """Return the resolved disturbance parameters for the part."""
+
+        base: MutableMapping[str, Any] = dict(self.context.get("disturbance", {}))
+        base.update(self.disturbance_overrides)
+        return dict(base)
+
+    def apply_action(self, action: StandAction) -> DispatchRecord:
+        """Execute ``action`` against this part and return a dispatch record."""
+
+        cost = action.cost_for(self)
+        harvest = action.harvest_for(self)
+        result = action.execute(self)
+        return DispatchRecord(
+            part=self.name,
+            action=action.name,
+            cost=cost,
+            harvest=harvest,
+            result=result,
+        )
+
+
+class StandComposite:
+    """Coordinate actions and shared constraints across multiple stand parts."""
+
+    def __init__(
+        self,
+        parts: Optional[Iterable[StandPart]] = None,
+        *,
+        budget: Optional[float] = None,
+        harvest_cap: Optional[float] = None,
+    ) -> None:
+        self._parts: Dict[str, StandPart] = {}
+        self.budget = budget
+        self.harvest_cap = harvest_cap
+        for part in parts or ():
+            self.add_part(part)
+
+    @property
+    def parts(self) -> Tuple[StandPart, ...]:
+        """Return the registered stand parts."""
+
+        return tuple(self._parts.values())
+
+    def add_part(self, part: StandPart) -> None:
+        """Register ``part`` with the composite."""
+
+        if part.name in self._parts:
+            raise ValueError(f"Duplicate stand part name: {part.name}")
+        self._parts[part.name] = part
+
+    def get_part(self, name: str) -> StandPart:
+        """Return the :class:`StandPart` registered under ``name``."""
+
+        try:
+            return self._parts[name]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"Unknown stand part: {name}") from exc
+
+    @property
+    def total_basal_area(self) -> float:
+        """Aggregate basal area across all parts."""
+
+        return float(sum(part.basal_area for part in self._parts.values()))
+
+    @property
+    def total_stems(self) -> float:
+        """Aggregate stem counts across all parts."""
+
+        return float(sum(part.stems for part in self._parts.values()))
+
+    @property
+    def total_cash(self) -> float:
+        """Aggregate cash contributions across all parts."""
+
+        return float(sum(part.cash for part in self._parts.values()))
+
+    def _select_parts(
+        self,
+        action: StandAction,
+        policy: PolicySelector,
+    ) -> Tuple[StandPart, ...]:
+        """Select stand parts that should receive ``action``."""
+
+        available_parts = self.parts
+        if callable(policy):
+            selected = tuple(policy(action, available_parts))
+            if not selected:
+                return ()
+            return selected
+        if policy == "broadcast":
+            return available_parts
+        if policy == "target":
+            targets = action.iter_targets()
+            if not targets:
+                raise ValueError("Targeted dispatch requires actions to declare target parts.")
+            return tuple(self.get_part(name) for name in targets)
+        if policy == "largest_first":
+            if not available_parts:
+                return ()
+            largest = max(available_parts, key=lambda item: item.basal_area)
+            return (largest,)
+        raise ValueError(f"Unknown dispatch policy: {policy}")
+
+    def dispatch(
+        self,
+        actions: Iterable[StandAction],
+        *,
+        policy: PolicySelector = "target",
+    ) -> DispatchResult:
+        """Dispatch ``actions`` to selected parts while enforcing constraints."""
+
+        result = DispatchResult()
+        for action in actions:
+            parts = self._select_parts(action, policy)
+            if not parts:
+                continue
+            for part in parts:
+                cost = action.cost_for(part)
+                harvest = action.harvest_for(part)
+                projected_spend = result.spent + cost
+                projected_harvest = result.harvested + harvest
+                if self.budget is not None and projected_spend - self.budget > 1e-9:
+                    raise RuntimeError(
+                        f"Dispatching action '{action.name}' would exceed the shared budget."
+                    )
+                if self.harvest_cap is not None and projected_harvest - self.harvest_cap > 1e-9:
+                    raise RuntimeError(
+                        f"Dispatching action '{action.name}' would exceed the harvest cap."
+                    )
+                record = part.apply_action(action)
+                result.records.append(record)
+        return result

--- a/src/pyforestry/simulation/stand_composite.py
+++ b/src/pyforestry/simulation/stand_composite.py
@@ -188,17 +188,23 @@ class StandPart:
         base.update(self.disturbance_overrides)
         return dict(base)
 
-    def apply_action(self, action: StandAction) -> DispatchRecord:
+    def apply_action(
+        self,
+        action: StandAction,
+        *,
+        cost: Optional[float] = None,
+        harvest: Optional[float] = None,
+    ) -> DispatchRecord:
         """Execute ``action`` against this part and return a dispatch record."""
 
-        cost = action.cost_for(self)
-        harvest = action.harvest_for(self)
+        resolved_cost = action.cost_for(self) if cost is None else float(cost)
+        resolved_harvest = action.harvest_for(self) if harvest is None else float(harvest)
         result = action.execute(self)
         return DispatchRecord(
             part=self.name,
             action=action.name,
-            cost=cost,
-            harvest=harvest,
+            cost=resolved_cost,
+            harvest=resolved_harvest,
             result=result,
         )
 
@@ -311,6 +317,6 @@ class StandComposite:
                     raise RuntimeError(
                         f"Dispatching action '{action.name}' would exceed the harvest cap."
                     )
-                record = part.apply_action(action)
+                record = part.apply_action(action, cost=cost, harvest=harvest)
                 result.records.append(record)
         return result

--- a/tests/simulation/test_stand_composite.py
+++ b/tests/simulation/test_stand_composite.py
@@ -1,0 +1,186 @@
+"""Tests for stand composite coordination helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List
+
+import pytest
+
+from pyforestry.simulation import (
+    DispatchResult,
+    StandAction,
+    StandComposite,
+    StandPart,
+)
+
+
+@dataclass
+class DummyModelView:
+    """Simple view exposing stand-level metrics for tests."""
+
+    basal_area: float
+    stems: float
+    cash: float
+
+    def total(self, metric_name: str) -> float:
+        values = {"BasalArea": self.basal_area, "Stems": self.stems, "Cash": self.cash}
+        return float(values[metric_name])
+
+
+def _tracking_handler(history: List[str], action_name: str) -> Any:
+    """Create a handler that records the part name before returning."""
+
+    def handler(part: StandPart) -> str:
+        history.append(f"{part.name}:{action_name}")
+        return f"handled:{part.name}:{action_name}"
+
+    return handler
+
+
+def test_composite_aggregates_metrics_and_context() -> None:
+    """Basal area, stems and cash are aggregated across all parts."""
+
+    north = StandPart(
+        "north",
+        model_view=DummyModelView(10.5, 120, 45.0),
+        context={"growth": {"target_ba": 12.0}},
+        growth_overrides={"target_ba": 15.0},
+    )
+    south = StandPart(
+        "south",
+        model_view=DummyModelView(7.0, 90, 30.0),
+        context={"disturbance": {"fire": 0.1}},
+        disturbance_overrides={"fire": 0.2},
+    )
+    unmanaged = StandPart(
+        "reserve",
+        model_view=object(),
+        context={"basal_area": 2.5, "stems": 40, "cash": 12.0},
+    )
+    composite = StandComposite([north, south, unmanaged])
+
+    assert composite.total_basal_area == pytest.approx(20.0)
+    assert composite.total_stems == pytest.approx(250.0)
+    assert composite.total_cash == pytest.approx(87.0)
+    assert north.growth_parameters == {"target_ba": 15.0}
+    assert south.disturbance_parameters == {"fire": 0.2}
+
+
+def test_dispatch_enforces_budget_and_harvest_caps() -> None:
+    """Dispatch stops when the shared constraints would be exceeded."""
+
+    composite = StandComposite(
+        [
+            StandPart("north", DummyModelView(5.0, 50, 10.0)),
+            StandPart("south", DummyModelView(3.0, 40, 8.0)),
+        ],
+        budget=100.0,
+        harvest_cap=5.0,
+    )
+
+    history: List[str] = []
+    actions = [
+        StandAction(
+            "thin-north",
+            _tracking_handler(history, "thin"),
+            cost=40.0,
+            harvest=2.0,
+            target_parts="north",
+        ),
+        StandAction(
+            "thin-south",
+            _tracking_handler(history, "thin"),
+            cost=35.0,
+            harvest=1.5,
+            target_parts="south",
+        ),
+        StandAction(
+            "extra",
+            _tracking_handler(history, "extra"),
+            cost=30.0,
+            harvest=1.0,
+            target_parts="north",
+        ),
+    ]
+    with pytest.raises(RuntimeError, match="budget"):
+        composite.dispatch(actions, policy="target")
+    # Only the first two actions should have executed.
+    assert history == ["north:thin", "south:thin"]
+
+    harvest_history: List[str] = []
+    harvest_actions = [
+        StandAction(
+            "first",
+            _tracking_handler(harvest_history, "harvest"),
+            cost=10.0,
+            harvest=3.0,
+            target_parts="north",
+        ),
+        StandAction(
+            "second",
+            _tracking_handler(harvest_history, "harvest"),
+            cost=15.0,
+            harvest=3.0,
+            target_parts="south",
+        ),
+    ]
+    with pytest.raises(RuntimeError, match="harvest cap"):
+        composite.dispatch(harvest_actions, policy="target")
+    assert harvest_history == ["north:harvest"]
+
+
+def test_dispatch_policies_route_to_expected_parts() -> None:
+    """Built-in and custom policies determine which parts receive actions."""
+
+    parts = [
+        StandPart("north", DummyModelView(12.0, 110, 50.0), context={"region": "north"}),
+        StandPart("south", DummyModelView(8.0, 90, 40.0), context={"region": "south"}),
+        StandPart("central", DummyModelView(5.0, 80, 30.0), context={"region": "central"}),
+    ]
+    composite = StandComposite(parts)
+
+    # Targeted dispatch.
+    history: List[str] = []
+    result = composite.dispatch(
+        [StandAction("tend", _tracking_handler(history, "tend"), target_parts="north")],
+        policy="target",
+    )
+    assert isinstance(result, DispatchResult)
+    assert [(record.part, record.action) for record in result.records] == [("north", "tend")]
+
+    # Broadcast dispatch hits every part.
+    history.clear()
+    result = composite.dispatch(
+        [StandAction("fertilize", _tracking_handler(history, "fert"))],
+        policy="broadcast",
+    )
+    assert sorted((record.part, record.action) for record in result.records) == [
+        ("central", "fertilize"),
+        ("north", "fertilize"),
+        ("south", "fertilize"),
+    ]
+
+    # Largest-first dispatch picks the part with the largest basal area.
+    history.clear()
+    result = composite.dispatch(
+        [StandAction("thin", _tracking_handler(history, "thin"))],
+        policy="largest_first",
+    )
+    assert [(record.part, record.action) for record in result.records] == [("north", "thin")]
+
+    # Custom policy selecting parts by region flag.
+    def north_and_central(action: StandAction, available: tuple[StandPart, ...]):
+        return tuple(
+            part for part in available if part.context.get("region") in {"north", "central"}
+        )
+
+    history.clear()
+    result = composite.dispatch(
+        [StandAction("survey", _tracking_handler(history, "survey"))],
+        policy=north_and_central,
+    )
+    assert sorted((record.part, record.action) for record in result.records) == [
+        ("central", "survey"),
+        ("north", "survey"),
+    ]


### PR DESCRIPTION
## Summary
- add stand composite orchestration classes with aggregation, dispatch, and constraint enforcement
- expose the new composite helpers from the simulation package
- cover composite aggregation, budget/harvest limits, and dispatch policy routing in unit tests

## Testing
- ruff check . --fix
- ruff format .
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50

------
https://chatgpt.com/codex/tasks/task_e_68ea58a1833c8329a8eadbb34c03b4f8