### PR TITLE
Add valuation ledger and volume connector integration

### DIFF
--- a/src/pyforestry/simulation/__init__.py
+++ b/src/pyforestry/simulation/__init__.py
@@ -1,5 +1,14 @@
-"""Simulation-facing views that expose helper-layer data."""
+"""Simulation-facing views and orchestration helpers."""
 
+from .growth_module import (
+    DisturbanceStage,
+    GrowthModule,
+    GrowthStage,
+    ManagementStage,
+    Stage,
+    StageAction,
+    ValuationStage,
+)
 from .model_view import InventoryView, SpatialTreeView, StandMetricView
 from .stand_composite import (
     DispatchRecord,
@@ -7,6 +16,17 @@ from .stand_composite import (
     StandAction,
     StandComposite,
     StandPart,
+)
+from .valuation import (
+    CohortRemoval,
+    EmptyVolumeDescriptor,
+    PieceRecord,
+    StandRemovalLedger,
+    TreeRemoval,
+    TreeVolumeDescriptor,
+    VolumeConnector,
+    VolumeDescriptor,
+    VolumeResult,
 )
 
 __all__ = [
@@ -18,4 +38,20 @@ __all__ = [
     "StandAction",
     "StandComposite",
     "StandPart",
+    "GrowthModule",
+    "GrowthStage",
+    "ManagementStage",
+    "DisturbanceStage",
+    "ValuationStage",
+    "Stage",
+    "StageAction",
+    "StandRemovalLedger",
+    "CohortRemoval",
+    "TreeRemoval",
+    "VolumeDescriptor",
+    "EmptyVolumeDescriptor",
+    "TreeVolumeDescriptor",
+    "VolumeResult",
+    "VolumeConnector",
+    "PieceRecord",
 ]

--- a/src/pyforestry/simulation/valuation/__init__.py
+++ b/src/pyforestry/simulation/valuation/__init__.py
@@ -1,0 +1,23 @@
+"""Valuation helpers for converting removals into marketable products."""
+
+from .removals import CohortRemoval, StandRemovalLedger, TreeRemoval
+from .volume import (
+    EmptyVolumeDescriptor,
+    PieceRecord,
+    TreeVolumeDescriptor,
+    VolumeConnector,
+    VolumeDescriptor,
+    VolumeResult,
+)
+
+__all__ = [
+    "CohortRemoval",
+    "StandRemovalLedger",
+    "TreeRemoval",
+    "PieceRecord",
+    "VolumeResult",
+    "VolumeDescriptor",
+    "EmptyVolumeDescriptor",
+    "TreeVolumeDescriptor",
+    "VolumeConnector",
+]

--- a/src/pyforestry/simulation/valuation/removals.py
+++ b/src/pyforestry/simulation/valuation/removals.py
@@ -1,0 +1,265 @@
+"""Removal ledger data structures for stand valuation workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Iterator, Mapping, MutableMapping, Optional
+
+from pyforestry.base.helpers import Tree
+from pyforestry.base.helpers.tree_species import TreeName, parse_tree_species
+from pyforestry.base.timber import Timber
+
+
+def _normalise_species(species: TreeName | str) -> TreeName:
+    """Return a :class:`TreeName` instance for ``species``."""
+
+    if isinstance(species, TreeName):
+        return species
+    if isinstance(species, str):
+        return parse_tree_species(species)
+    raise TypeError("Species must be a TreeName or parsable string.")
+
+
+def _merge_metadata(*sources: Mapping[str, Any] | None) -> Dict[str, Any]:
+    """Merge mapping objects from left to right into a new dictionary."""
+
+    merged: Dict[str, Any] = {}
+    for source in sources:
+        if not source:
+            continue
+        merged.update(source)
+    return merged
+
+
+@dataclass
+class TreeRemoval:
+    """Record the removal of an individual (possibly weighted) tree."""
+
+    cohort_id: str
+    species: TreeName | str
+    tree: Tree
+    weight: float | None = None
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.cohort_id:
+            raise ValueError("Tree removals require a cohort identifier.")
+        if not isinstance(self.tree, Tree):
+            raise TypeError("TreeRemoval expects a Tree instance.")
+        self.species = _normalise_species(self.species)
+        resolved_weight = self.weight
+        if resolved_weight is None:
+            resolved_weight = self.tree.weight_n or 1.0
+        if resolved_weight <= 0:
+            raise ValueError("Removal weights must be positive.")
+        self.weight = float(resolved_weight)
+        self.metadata = dict(self.metadata)
+        self.metadata.setdefault("cohort_id", self.cohort_id)
+        self.metadata.setdefault("species", self.species.full_name)
+
+    @property
+    def species_name(self) -> str:
+        """Return the lower-case ``"genus species"`` representation."""
+
+        return self.species.full_name
+
+    @property
+    def diameter_cm(self) -> float:
+        """Return the tree diameter in centimetres."""
+
+        diameter = self.tree.diameter_cm
+        if diameter is None:
+            raise ValueError("Tree removals require diameter measurements.")
+        return float(diameter)
+
+    @property
+    def height_m(self) -> float:
+        """Return the tree height in metres."""
+
+        height = self.tree.height_m
+        if height is None:
+            raise ValueError("Tree removals require height measurements.")
+        return float(height)
+
+    @property
+    def stump_height_m(self) -> float:
+        """Return the stump height in metres for the removal."""
+
+        stump = self.metadata.get("stump_height_m")
+        if stump is not None:
+            return float(stump)
+        stump_from_tree = getattr(self.tree, "stump_height_m", None)
+        if stump_from_tree is not None:
+            return float(stump_from_tree)
+        return 0.3
+
+    def to_timber(self) -> Timber:
+        """Convert the removal into a :class:`~pyforestry.base.timber.Timber`."""
+
+        kwargs: Dict[str, Any] = {}
+        for key in ("double_bark_mm", "crown_base_height_m", "over_bark"):
+            if key in self.metadata:
+                kwargs[key] = self.metadata[key]
+        return Timber(
+            species=self.species_name,
+            diameter_cm=self.diameter_cm,
+            height_m=self.height_m,
+            stump_height_m=self.stump_height_m,
+            **kwargs,
+        )
+
+
+@dataclass
+class CohortRemoval:
+    """Group a collection of removed trees for a cohort."""
+
+    identifier: str
+    species: TreeName | str
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+    trees: list[TreeRemoval] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.identifier:
+            raise ValueError("Cohort removals require an identifier.")
+        self.species = _normalise_species(self.species)
+        self.metadata = dict(self.metadata)
+        self.metadata.setdefault("species", self.species.full_name)
+
+    def record_tree(
+        self,
+        tree: Tree,
+        *,
+        weight: float | None = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> TreeRemoval:
+        """Append a tree removal to the cohort."""
+
+        combined = _merge_metadata(self.metadata, metadata)
+        removal = TreeRemoval(
+            cohort_id=self.identifier,
+            species=self.species,
+            tree=tree,
+            weight=weight,
+            metadata=combined,
+        )
+        self.trees.append(removal)
+        return removal
+
+    def iter_trees(self) -> Iterator[TreeRemoval]:
+        """Yield the recorded tree removals."""
+
+        yield from self.trees
+
+    @property
+    def tree_count(self) -> int:
+        """Return the number of recorded tree removals."""
+
+        return len(self.trees)
+
+    @property
+    def total_weight(self) -> float:
+        """Return the sum of removal weights in the cohort."""
+
+        return float(sum(tree.weight for tree in self.trees))
+
+
+@dataclass
+class StandRemovalLedger:
+    """Top-level container aggregating removal cohorts for a stand."""
+
+    stand_id: Optional[str] = None
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+    cohorts: MutableMapping[str, CohortRemoval] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.metadata = dict(self.metadata)
+        self.cohorts = dict(self.cohorts)
+        if self.stand_id:
+            self.metadata.setdefault("stand_id", self.stand_id)
+
+    def add_cohort(
+        self,
+        identifier: str,
+        *,
+        species: TreeName | str,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> CohortRemoval:
+        """Register a cohort and return it (existing cohorts are updated)."""
+
+        if identifier in self.cohorts:
+            cohort = self.cohorts[identifier]
+            cohort.metadata.update(metadata or {})
+            return cohort
+        cohort = CohortRemoval(
+            identifier=identifier,
+            species=species,
+            metadata=dict(metadata or {}),
+        )
+        self.cohorts[identifier] = cohort
+        return cohort
+
+    def record_tree(
+        self,
+        identifier: str,
+        tree: Tree,
+        *,
+        species: TreeName | str | None = None,
+        weight: float | None = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> TreeRemoval:
+        """Record a tree removal under ``identifier`` and return the entry."""
+
+        cohort = self.cohorts.get(identifier)
+        if cohort is None:
+            if species is None:
+                if tree.species is None:
+                    raise ValueError("Species must be provided when creating a new cohort.")
+                species = tree.species
+            cohort = self.add_cohort(identifier, species=species, metadata=metadata)
+        else:
+            if species is not None and _normalise_species(species) != cohort.species:
+                raise ValueError("Species for tree removal does not match cohort species.")
+        return cohort.record_tree(tree, weight=weight, metadata=metadata)
+
+    def iter_cohorts(self) -> Iterator[CohortRemoval]:
+        """Yield the registered cohorts."""
+
+        yield from self.cohorts.values()
+
+    def iter_tree_removals(self) -> Iterator[TreeRemoval]:
+        """Yield tree removals across all cohorts."""
+
+        for cohort in self.iter_cohorts():
+            yield from cohort.iter_trees()
+
+    @property
+    def is_empty(self) -> bool:
+        """Return ``True`` when no tree removals are recorded."""
+
+        return all(cohort.tree_count == 0 for cohort in self.cohorts.values())
+
+    @property
+    def tree_count(self) -> int:
+        """Return the total number of tree removals."""
+
+        return sum(cohort.tree_count for cohort in self.cohorts.values())
+
+    @property
+    def total_weight(self) -> float:
+        """Return the total removal weight across cohorts."""
+
+        return float(sum(cohort.total_weight for cohort in self.cohorts.values()))
+
+    def extend(self, cohorts: Iterable[CohortRemoval]) -> None:
+        """Merge ``cohorts`` into the ledger."""
+
+        for cohort in cohorts:
+            existing = self.cohorts.get(cohort.identifier)
+            if existing is None:
+                self.cohorts[cohort.identifier] = cohort
+                continue
+            for tree in cohort.iter_trees():
+                existing.record_tree(tree.tree, weight=tree.weight, metadata=tree.metadata)
+
+
+__all__ = ["TreeRemoval", "CohortRemoval", "StandRemovalLedger"]

--- a/src/pyforestry/simulation/valuation/volume.py
+++ b/src/pyforestry/simulation/valuation/volume.py
@@ -1,0 +1,273 @@
+"""Volume conversion utilities for valuation workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, Mapping, MutableMapping, Tuple, Type
+
+from pyforestry.base.helpers.bucking import BuckingConfig, QualityType
+from pyforestry.base.pricelist import Pricelist
+from pyforestry.base.taper import Taper
+from pyforestry.base.timber_bucking.nasberg_1985 import Nasberg_1985_BranchBound
+
+from .removals import StandRemovalLedger, TreeRemoval
+
+
+@dataclass(frozen=True)
+class PieceRecord:
+    """Representation of one bucked piece aggregated across identical trees."""
+
+    cohort_id: str
+    species: str
+    quality: QualityType
+    length_m: float
+    top_diameter_cm: float
+    volume_m3: float
+    value: float
+    weight: float
+
+    def as_mapping(self) -> Dict[str, Any]:
+        """Return a plain mapping useful for serialisation."""
+
+        return {
+            "cohort_id": self.cohort_id,
+            "species": self.species,
+            "quality": self.quality.name,
+            "length_m": self.length_m,
+            "top_diameter_cm": self.top_diameter_cm,
+            "volume_m3": self.volume_m3,
+            "value": self.value,
+            "weight": self.weight,
+        }
+
+
+@dataclass(frozen=True)
+class VolumeResult:
+    """Container describing the outcome of a valuation conversion."""
+
+    descriptor: "VolumeDescriptor"
+    pieces: Tuple[PieceRecord, ...]
+    total_value: float
+    volume_by_quality: Mapping[QualityType, float]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def total_volume(self) -> float:
+        """Return the total merchantable volume (m³)."""
+
+        return float(sum(piece.volume_m3 for piece in self.pieces))
+
+
+@dataclass(kw_only=True)
+class VolumeDescriptor:
+    """Base descriptor for conversion inputs."""
+
+    ledger: StandRemovalLedger
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.metadata = dict(self.metadata)
+        if self.ledger.stand_id:
+            self.metadata.setdefault("stand_id", self.ledger.stand_id)
+
+    def evaluate(self) -> VolumeResult:
+        """Return an empty result for descriptors that cannot produce volume."""
+
+        return VolumeResult(
+            descriptor=self,
+            pieces=(),
+            total_value=0.0,
+            volume_by_quality={quality: 0.0 for quality in QualityType},
+            metadata=dict(self.metadata),
+        )
+
+
+@dataclass(kw_only=True)
+class EmptyVolumeDescriptor(VolumeDescriptor):
+    """Descriptor used when no removals are present."""
+
+    reason: str = "empty"
+
+    def evaluate(self) -> VolumeResult:  # type: ignore[override]
+        base = super().evaluate()
+        metadata = dict(base.metadata)
+        metadata.setdefault("reason", self.reason)
+        return VolumeResult(
+            descriptor=base.descriptor,
+            pieces=base.pieces,
+            total_value=base.total_value,
+            volume_by_quality=base.volume_by_quality,
+            metadata=metadata,
+        )
+
+
+@dataclass(kw_only=True)
+class TreeVolumeDescriptor(VolumeDescriptor):
+    """Descriptor based on individual tree removals."""
+
+    removals: Tuple[TreeRemoval, ...]
+    pricelist: Pricelist
+    taper_class: Type[Taper]
+    bucking_config: BuckingConfig = field(
+        default_factory=lambda: BuckingConfig(save_sections=True)
+    )
+    bucker_cls: Type[Nasberg_1985_BranchBound] = Nasberg_1985_BranchBound
+    min_diam_dead_wood: float = 0.0
+
+    def evaluate(self) -> VolumeResult:  # type: ignore[override]
+        if not self.removals:
+            return super().evaluate()
+
+        config = self.bucking_config
+        if not isinstance(config, BuckingConfig):
+            raise TypeError("Bucking configuration must be a BuckingConfig instance.")
+        if not config.save_sections:
+            config = replace(config, save_sections=True)
+
+        pieces: list[PieceRecord] = []
+        total_value = 0.0
+        volume_by_quality: Dict[QualityType, float] = {quality: 0.0 for quality in QualityType}
+
+        for removal in self.removals:
+            timber = removal.to_timber()
+            bucker = self.bucker_cls(timber, self.pricelist, self.taper_class)
+            result = bucker.calculate_tree_value(
+                min_diam_dead_wood=self.min_diam_dead_wood,
+                config=config,
+            )
+            weight = removal.weight
+            total_value += float(result.total_value) * weight
+            for idx, volume in enumerate(result.volume_per_quality):
+                try:
+                    quality = QualityType(idx)
+                except ValueError:
+                    continue
+                volume_by_quality[quality] += float(volume) * weight
+
+            sections = result.sections or []
+            if sections:
+                for section in sections:
+                    length_m = (section.end_point - section.start_point) / 10.0
+                    pieces.append(
+                        PieceRecord(
+                            cohort_id=removal.cohort_id,
+                            species=removal.species_name,
+                            quality=section.quality,
+                            length_m=length_m,
+                            top_diameter_cm=float(section.top_diameter),
+                            volume_m3=float(section.volume) * weight,
+                            value=float(section.value) * weight,
+                            weight=weight,
+                        )
+                    )
+            else:
+                # Fall back to aggregating the total sk volume when sections are absent.
+                pieces.append(
+                    PieceRecord(
+                        cohort_id=removal.cohort_id,
+                        species=removal.species_name,
+                        quality=QualityType.Undefined,
+                        length_m=removal.height_m,
+                        top_diameter_cm=removal.diameter_cm,
+                        volume_m3=float(result.vol_sk_ub) * weight,
+                        value=float(result.total_value) * weight,
+                        weight=weight,
+                    )
+                )
+
+        metadata = dict(self.metadata)
+        metadata.setdefault("cohort_count", len(self.ledger.cohorts))
+        metadata.setdefault("tree_count", self.ledger.tree_count)
+
+        return VolumeResult(
+            descriptor=self,
+            pieces=tuple(pieces),
+            total_value=float(total_value),
+            volume_by_quality=volume_by_quality,
+            metadata=metadata,
+        )
+
+
+class VolumeConnector:
+    """Resolve removal ledgers into volume descriptors and valuation results."""
+
+    def __init__(self, *, bucker_cls: Type[Nasberg_1985_BranchBound] | None = None) -> None:
+        self._bucker_cls = bucker_cls or Nasberg_1985_BranchBound
+
+    def describe(self, model_view: Any, ledger: StandRemovalLedger) -> VolumeDescriptor:
+        """Return the descriptor describing ``ledger`` for ``model_view``."""
+
+        if not isinstance(ledger, StandRemovalLedger):
+            raise TypeError("ledger must be a StandRemovalLedger instance.")
+        if ledger.is_empty:
+            return EmptyVolumeDescriptor(ledger=ledger, metadata=dict(ledger.metadata))
+
+        removals = tuple(ledger.iter_tree_removals())
+        pricelist = self._resolve_pricelist(model_view)
+        taper_class = self._resolve_taper_class(model_view)
+        config = self._resolve_bucking_config(model_view)
+        min_dead = float(getattr(model_view, "min_diam_dead_wood", 0.0))
+
+        return TreeVolumeDescriptor(
+            ledger=ledger,
+            removals=removals,
+            pricelist=pricelist,
+            taper_class=taper_class,
+            bucking_config=config,
+            bucker_cls=self._bucker_cls,
+            min_diam_dead_wood=min_dead,
+            metadata=dict(ledger.metadata),
+        )
+
+    def connect(self, model_view: Any, ledger: StandRemovalLedger) -> VolumeResult:
+        """Return the evaluated volume result for ``ledger`` and ``model_view``."""
+
+        descriptor = self.describe(model_view, ledger)
+        return descriptor.evaluate()
+
+    @staticmethod
+    def _resolve_pricelist(model_view: Any) -> Pricelist:
+        candidates = (
+            getattr(model_view, "pricelist", None),
+            getattr(model_view, "price_list", None),
+        )
+        for candidate in candidates:
+            resolved = candidate() if callable(candidate) else candidate
+            if isinstance(resolved, Pricelist):
+                return resolved
+        raise AttributeError("Model view must provide a Pricelist via 'pricelist'.")
+
+    @staticmethod
+    def _resolve_taper_class(model_view: Any) -> Type[Taper]:
+        candidate = getattr(model_view, "taper_class", None)
+        if callable(candidate) and not isinstance(candidate, type):
+            candidate = candidate()
+        if candidate is None:
+            getter = getattr(model_view, "get_taper_class", None)
+            candidate = getter() if callable(getter) else None
+        if not isinstance(candidate, type) or not issubclass(candidate, Taper):
+            raise AttributeError("Model view must supply a taper_class derived from Taper.")
+        return candidate
+
+    @staticmethod
+    def _resolve_bucking_config(model_view: Any) -> BuckingConfig:
+        candidate = getattr(model_view, "bucking_config", None)
+        if callable(candidate):
+            candidate = candidate()
+        if candidate is None:
+            return BuckingConfig(save_sections=True)
+        if not isinstance(candidate, BuckingConfig):
+            raise TypeError("bucking_config must be a BuckingConfig instance.")
+        if not candidate.save_sections:
+            candidate = replace(candidate, save_sections=True)
+        return candidate
+
+
+__all__ = [
+    "PieceRecord",
+    "VolumeResult",
+    "VolumeDescriptor",
+    "EmptyVolumeDescriptor",
+    "TreeVolumeDescriptor",
+    "VolumeConnector",
+]

--- a/tests/simulation/test_volume_connector.py
+++ b/tests/simulation/test_volume_connector.py
@@ -1,0 +1,133 @@
+"""Tests covering removal ledgers and volume conversion utilities."""
+
+from __future__ import annotations
+
+from math import pi
+
+import pytest
+
+from pyforestry.base.helpers import Tree
+from pyforestry.base.helpers.tree_species import PINUS_SYLVESTRIS
+from pyforestry.base.pricelist.pricelist import (
+    LengthRange,
+    Pricelist,
+    TimberPriceForDiameter,
+    TimberPricelist,
+)
+from pyforestry.base.taper.taper import Taper
+from pyforestry.base.timber.timber_base import Timber
+from pyforestry.base.timber_bucking.nasberg_1985 import BuckingConfig, QualityType
+from pyforestry.simulation import StandComposite, StandPart
+from pyforestry.simulation.growth_module import GrowthModule
+from pyforestry.simulation.valuation import StandRemovalLedger, VolumeConnector
+
+
+class ConstantTaper(Taper):
+    """Simple taper returning a constant diameter up to tree height."""
+
+    def __init__(self, timber: Timber):
+        self.diameter = timber.diameter_cm
+        self.height = timber.height_m
+        super().__init__(timber, self)
+
+    def get_diameter_at_height(self, height_m: float) -> float:  # type: ignore[override]
+        return self.diameter if 0 <= height_m <= self.height else 0.0
+
+    def get_height_at_diameter(self, diameter: float) -> float:  # type: ignore[override]
+        return self.height
+
+    def volume_section(self, h1_m: float, h2_m: float) -> float:  # type: ignore[override]
+        radius = self.diameter / 200
+        return max(0.0, h2_m - h1_m) * pi * radius * radius
+
+
+def _make_pricelist() -> Pricelist:
+    pricelist = Pricelist()
+    table = TimberPricelist(15, 15, volume_type="m3fub")
+    table.set_price_for_diameter(15, TimberPriceForDiameter(10, 10, 10))
+    pricelist.Timber[PINUS_SYLVESTRIS.full_name] = table
+    pricelist.PulpLogLength = LengthRange(2.0, 2.0)
+    pricelist.TimberLogLength = LengthRange(2.0, 2.0)
+    pricelist.Pulp._prices[PINUS_SYLVESTRIS.full_name] = 1
+    pricelist.LogCullPrice = 0
+    pricelist.FuelWoodPrice = 0
+    return pricelist
+
+
+def test_removal_ledger_tracks_metadata_and_weights() -> None:
+    """Recording tree removals captures cohort metadata and weights."""
+
+    ledger = StandRemovalLedger("stand-1", metadata={"region": "north"})
+    ledger.add_cohort("thin-2024", species=PINUS_SYLVESTRIS, metadata={"treatment": "thin"})
+
+    tree = Tree(species=PINUS_SYLVESTRIS, diameter_cm=15.0, height_m=6.0, weight_n=2.5)
+    removal = ledger.record_tree("thin-2024", tree, metadata={"stump_height_m": 0.15})
+
+    assert ledger.tree_count == 1
+    assert ledger.total_weight == pytest.approx(2.5)
+    assert removal.metadata["treatment"] == "thin"
+    assert removal.stump_height_m == pytest.approx(0.15)
+    assert removal.species_name == PINUS_SYLVESTRIS.full_name
+
+
+def test_volume_connector_handles_empty_ledgers() -> None:
+    """When no removals are present an empty descriptor is returned."""
+
+    ledger = StandRemovalLedger()
+    connector = VolumeConnector()
+    result = connector.connect(object(), ledger)
+
+    assert result.total_value == 0.0
+    assert result.pieces == ()
+    assert result.metadata.get("reason") == "empty"
+
+
+def test_volume_connector_and_stage_produce_cash_flows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bucking conversion integrates with the valuation stage."""
+
+    monkeypatch.setattr(
+        Pricelist,
+        "getPulpWoodWasteProportion",
+        lambda self, species: 0.0,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        Pricelist,
+        "getPulpwoodFuelwoodProportion",
+        lambda self, species: 0.0,
+        raising=False,
+    )
+
+    ledger = StandRemovalLedger("stand-valuation")
+    tree = Tree(species=PINUS_SYLVESTRIS, diameter_cm=15.0, height_m=6.0, weight_n=1.0)
+    ledger.record_tree("thin-2024", tree, metadata={"stump_height_m": 0.0})
+
+    class DummyView:
+        removal_ledger = ledger
+        pricelist = _make_pricelist()
+        taper_class = ConstantTaper
+        bucking_config = BuckingConfig(use_downgrading=True, save_sections=True)
+        min_diam_dead_wood = 16
+
+    view = DummyView()
+    connector = VolumeConnector()
+    expected = connector.connect(view, ledger)
+
+    assert expected.total_value > 0.0
+    assert len(expected.pieces) == 1
+    piece = expected.pieces[0]
+    assert piece.quality == QualityType.ButtLog
+    assert piece.volume_m3 == pytest.approx(0.10603, rel=1e-4)
+    assert piece.value == pytest.approx(expected.total_value, rel=1e-6)
+    assert expected.volume_by_quality[QualityType.ButtLog] == pytest.approx(0.10603, rel=1e-4)
+
+    part = StandPart("north", model_view=view, context={"cash": 1.0})
+    composite = StandComposite([part])
+    module = GrowthModule(composite)
+
+    module.run_cycle()
+
+    valuation_ctx = part.context["valuation"]
+    assert valuation_ctx["total_value"] == pytest.approx(expected.total_value, rel=1e-6)
+    assert valuation_ctx["pieces"][0].volume_m3 == pytest.approx(piece.volume_m3, rel=1e-6)
+    assert part.context["cash"] == pytest.approx(1.0 + expected.total_value, rel=1e-6)


### PR DESCRIPTION
## Summary
- add removal ledger dataclasses and valuation exports for the simulation package
- implement volume descriptors and connector that drive bucking outputs into cash metrics
- wire a valuation stage into the growth module and cover the flow with new tests

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ea6389c9a88329b479cdeaa2ae2397