### PR TITLE
Add deterministic RNG services and telemetry to growth simulations

### DIFF
--- a/src/pyforestry/simulation/services/__init__.py
+++ b/src/pyforestry/simulation/services/__init__.py
@@ -1,0 +1,15 @@
+"""Support services shared across simulation modules."""
+
+from .checkpoint import CheckpointSerializer, CompositeMemento
+from .keyed_rng import KeyedRNG
+from .rng_bundle import RandomBundle
+from .telemetry import TelemetryEvent, TelemetryPublisher
+
+__all__ = [
+    "CompositeMemento",
+    "CheckpointSerializer",
+    "KeyedRNG",
+    "RandomBundle",
+    "TelemetryEvent",
+    "TelemetryPublisher",
+]

--- a/src/pyforestry/simulation/services/checkpoint.py
+++ b/src/pyforestry/simulation/services/checkpoint.py
@@ -1,0 +1,59 @@
+"""Checkpoint helpers for serialising and restoring simulation state."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Dict, Mapping, Tuple
+
+if False:  # pragma: no cover - typing aid
+    from pyforestry.simulation.stand_composite import StandComposite
+
+
+@dataclass
+class CompositeMemento:
+    """Serializable snapshot of a stand composite."""
+
+    seed: int
+    contexts: Dict[str, Mapping[str, object]]
+    growth_overrides: Dict[str, Mapping[str, object]]
+    disturbance_overrides: Dict[str, Mapping[str, object]]
+    rng_states: Dict[Tuple[str, ...], object]
+
+
+class CheckpointSerializer:
+    """Capture and restore composite level state."""
+
+    def capture(self, composite: "StandComposite") -> CompositeMemento:
+        """Return a :class:`CompositeMemento` representing ``composite``."""
+
+        contexts: Dict[str, Mapping[str, object]] = {}
+        growth_overrides: Dict[str, Mapping[str, object]] = {}
+        disturbance_overrides: Dict[str, Mapping[str, object]] = {}
+        for name, part in composite._parts.items():  # noqa: SLF001 - serializer needs internals
+            contexts[name] = deepcopy(part.context)
+            growth_overrides[name] = deepcopy(part.growth_overrides or {})
+            disturbance_overrides[name] = deepcopy(part.disturbance_overrides or {})
+        rng_states = composite.random_bundle.snapshot()
+        return CompositeMemento(
+            seed=composite.seed,
+            contexts=contexts,
+            growth_overrides=growth_overrides,
+            disturbance_overrides=disturbance_overrides,
+            rng_states=rng_states,
+        )
+
+    def restore(self, composite: "StandComposite", memento: CompositeMemento) -> None:
+        """Restore ``composite`` state from ``memento``."""
+
+        composite.seed = memento.seed
+        composite.random_bundle.seed = memento.seed
+        composite.telemetry.seed = memento.seed
+        for name, part in composite._parts.items():  # noqa: SLF001 - serializer needs internals
+            if name in memento.contexts:
+                part.context = deepcopy(memento.contexts[name])
+            if name in memento.growth_overrides:
+                part.growth_overrides = deepcopy(memento.growth_overrides[name])
+            if name in memento.disturbance_overrides:
+                part.disturbance_overrides = deepcopy(memento.disturbance_overrides[name])
+        composite.random_bundle.restore(memento.rng_states)

--- a/src/pyforestry/simulation/services/keyed_rng.py
+++ b/src/pyforestry/simulation/services/keyed_rng.py
@@ -1,0 +1,69 @@
+"""Deterministic random number generators keyed by hierarchical identifiers."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+if False:  # pragma: no cover - typing aid
+    from .rng_bundle import RandomBundle
+
+
+@dataclass
+class KeyedRNG:
+    """Wrap :class:`random.Random` instances with deterministic key derivation."""
+
+    _bundle: "RandomBundle"
+    path: Tuple[str, ...]
+    seed: int
+
+    def __post_init__(self) -> None:
+        self._random = random.Random(self.seed)
+
+    def random(self) -> float:
+        """Return the next random floating point number in the range [0.0, 1.0)."""
+
+        return self._random.random()
+
+    def randint(self, a: int, b: int) -> int:
+        """Return a random integer N such that ``a <= N <= b``."""
+
+        return self._random.randint(a, b)
+
+    def uniform(self, a: float, b: float) -> float:
+        """Return a random floating point number ``N`` such that ``a <= N <= b``."""
+
+        return self._random.uniform(a, b)
+
+    def child(self, *keys: Iterable[str] | str) -> "KeyedRNG":
+        """Return a derived generator scoped by ``keys`` relative to ``path``."""
+
+        expanded: Tuple[str, ...] = self.path
+        for key in keys:
+            if isinstance(key, str):
+                expanded += (key,)
+            else:
+                expanded += tuple(str(item) for item in key)
+        return self._bundle.rng_for(*expanded)
+
+    @property
+    def state(self) -> object:
+        """Return the serialisable state of the underlying generator."""
+
+        return self._random.getstate()
+
+    @state.setter
+    def state(self, value: object) -> None:
+        """Restore the state of the underlying generator."""
+
+        self._random.setstate(value)
+
+    def jumpahead(self, steps: int) -> None:
+        """Advance the generator ``steps`` positions without yielding values."""
+
+        for _ in range(int(steps)):
+            self._random.random()
+
+    def __getattr__(self, name: str):  # pragma: no cover - passthrough
+        return getattr(self._random, name)

--- a/src/pyforestry/simulation/services/rng_bundle.py
+++ b/src/pyforestry/simulation/services/rng_bundle.py
@@ -1,0 +1,55 @@
+"""RNG bundle providing keyed deterministic streams for simulations."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Dict, Iterable, Tuple
+
+from .keyed_rng import KeyedRNG
+
+
+class RandomBundle:
+    """Manage keyed random number generators derived from a root seed."""
+
+    def __init__(self, seed: int) -> None:
+        self.seed = int(seed)
+        self._streams: Dict[Tuple[str, ...], KeyedRNG] = {}
+        # Initialise the root generator so snapshotting always includes it.
+        self._get_rng(())
+
+    def _derive_seed(self, path: Tuple[str, ...]) -> int:
+        if not path:
+            return self.seed
+        joined = "::".join(path).encode("utf8")
+        seed_bytes = (self.seed & ((1 << 64) - 1)).to_bytes(8, "big")
+        digest = hashlib.blake2b(joined, key=seed_bytes, digest_size=16)
+        return int.from_bytes(digest.digest(), "big")
+
+    def _normalize_path(self, keys: Iterable[object]) -> Tuple[str, ...]:
+        return tuple(str(key) for key in keys)
+
+    def _get_rng(self, path: Tuple[str, ...]) -> KeyedRNG:
+        rng = self._streams.get(path)
+        if rng is None:
+            rng = KeyedRNG(self, path, self._derive_seed(path))
+            self._streams[path] = rng
+        return rng
+
+    def rng_for(self, *keys: object) -> KeyedRNG:
+        """Return a generator scoped by ``keys`` relative to the root seed."""
+
+        return self._get_rng(self._normalize_path(keys))
+
+    def snapshot(self) -> Dict[Tuple[str, ...], object]:
+        """Return the states for all instantiated generators."""
+
+        return {path: rng.state for path, rng in self._streams.items()}
+
+    def restore(self, states: Dict[Tuple[str, ...], object]) -> None:
+        """Restore generator states from ``states`` returned by :meth:`snapshot`."""
+
+        self._streams.clear()
+        self._get_rng(())
+        for path, state in states.items():
+            rng = self._get_rng(path)
+            rng.state = state

--- a/src/pyforestry/simulation/services/telemetry.py
+++ b/src/pyforestry/simulation/services/telemetry.py
@@ -1,0 +1,53 @@
+"""Telemetry publishing helpers for simulation events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Mapping, Optional
+
+
+@dataclass
+class TelemetryEvent:
+    """Record emitted by :class:`TelemetryPublisher`."""
+
+    type: str
+    payload: Mapping[str, object]
+
+
+class TelemetryPublisher:
+    """Publish telemetry events, enriching payloads with provenance metadata."""
+
+    def __init__(
+        self,
+        *,
+        model_id: Optional[str],
+        seed: int,
+        sink: Optional[Callable[[TelemetryEvent], None]] = None,
+    ) -> None:
+        self.model_id = model_id or "unknown"
+        self.seed = int(seed)
+        self._events: List[TelemetryEvent] = []
+        self._sink = sink
+
+    def publish(self, event_type: str, payload: Mapping[str, object]) -> None:
+        """Emit a telemetry event augmented with provenance metadata."""
+
+        enriched: Dict[str, object] = {
+            "metadata": {"model_id": self.model_id, "seed": self.seed},
+            **dict(payload),
+        }
+        event = TelemetryEvent(type=event_type, payload=enriched)
+        self._events.append(event)
+        if self._sink is not None:
+            self._sink(event)
+
+    @property
+    def events(self) -> List[TelemetryEvent]:
+        """Return a copy of the recorded events."""
+
+        return list(self._events)
+
+    def clear(self) -> None:
+        """Discard buffered events."""
+
+        self._events.clear()


### PR DESCRIPTION
## Summary
- add simulation service modules for keyed RNG management, checkpoint serialization, and telemetry publishing
- integrate deterministic RNG streams, telemetry events, and checkpointing with the growth module and stand composite
- add regression tests covering RNG reproducibility, snapshot/restore behaviour, and telemetry metadata

## Testing
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50

------
https://chatgpt.com/codex/tasks/task_e_68ea6751de088329854a2bd686c5c51e