### PR TITLE
Add DP state key encoding and deterministic transitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
   "docstr-coverage",     # docstring coverage
   "coverage",            # coverage engine
   "ruff",
+  "hypothesis",          # property-based testing
   "build",
   "twine",
   "sphinx",              # docs tool

--- a/src/pyforestry/simulation/__init__.py
+++ b/src/pyforestry/simulation/__init__.py
@@ -1,5 +1,14 @@
 """Simulation-facing views and orchestration helpers."""
 
+from .dp import (
+    DeterministicAdapter,
+    ModelViewStateKey,
+    PartKey,
+    SimulationProvenance,
+    decode_model_views,
+    encode_model_views,
+    simulate_one_step_pure,
+)
 from .growth_module import (
     DisturbanceStage,
     GrowthModule,
@@ -54,4 +63,11 @@ __all__ = [
     "VolumeResult",
     "VolumeConnector",
     "PieceRecord",
+    "DeterministicAdapter",
+    "ModelViewStateKey",
+    "PartKey",
+    "SimulationProvenance",
+    "decode_model_views",
+    "encode_model_views",
+    "simulate_one_step_pure",
 ]

--- a/src/pyforestry/simulation/dp/__init__.py
+++ b/src/pyforestry/simulation/dp/__init__.py
@@ -1,0 +1,21 @@
+"""Dynamic programming helpers for simulation state management."""
+
+from .state_key import (
+    DeterministicAdapter,
+    ModelViewStateKey,
+    PartKey,
+    SimulationProvenance,
+    decode_model_views,
+    encode_model_views,
+    simulate_one_step_pure,
+)
+
+__all__ = [
+    "DeterministicAdapter",
+    "ModelViewStateKey",
+    "PartKey",
+    "SimulationProvenance",
+    "decode_model_views",
+    "encode_model_views",
+    "simulate_one_step_pure",
+]

--- a/src/pyforestry/simulation/dp/state_key.py
+++ b/src/pyforestry/simulation/dp/state_key.py
@@ -1,0 +1,173 @@
+"""Utilities for encoding model views into deterministic cache keys."""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, MutableMapping, Protocol, Tuple
+
+
+class DeterministicAdapter(Protocol):
+    """Protocol describing deterministic state transition adapters."""
+
+    adapter_id: str
+
+    def apply(self, *, part: str, action: str, model_view: Any) -> Tuple[Any, float]:
+        """Return the next model view for ``part`` and the reward for ``action``."""
+
+
+@dataclass(frozen=True)
+class SimulationProvenance:
+    """Identify the provenance of cached simulation results."""
+
+    connector_id: str
+    bucking_id: str
+    adapter_ids: Mapping[str, str]
+    _adapter_ids: Tuple[Tuple[str, str], ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.connector_id:
+            raise ValueError("connector_id must be a non-empty string.")
+        if not self.bucking_id:
+            raise ValueError("bucking_id must be a non-empty string.")
+        adapter_pairs = tuple(
+            sorted((str(part), str(adapter)) for part, adapter in dict(self.adapter_ids).items())
+        )
+        object.__setattr__(self, "adapter_ids", dict(adapter_pairs))
+        object.__setattr__(self, "_adapter_ids", adapter_pairs)
+
+    @property
+    def adapter_signature(self) -> Tuple[Tuple[str, str], ...]:
+        """Return a normalized tuple describing the adapters used."""
+
+        return self._adapter_ids
+
+    @property
+    def namespace(self) -> str:
+        """Return a cache namespace that encodes the full provenance."""
+
+        adapter_segment = ",".join(f"{part}={adapter}" for part, adapter in self.adapter_signature)
+        return (
+            f"connector={self.connector_id}|bucking={self.bucking_id}|adapters={adapter_segment}"
+        )
+
+    @classmethod
+    def from_adapters(
+        cls,
+        *,
+        connector_id: str,
+        bucking_id: str,
+        adapters: Mapping[str, DeterministicAdapter],
+    ) -> "SimulationProvenance":
+        """Build provenance information from the supplied ``adapters``."""
+
+        adapter_ids: Dict[str, str] = {}
+        for part, adapter in adapters.items():
+            adapter_ids[str(part)] = getattr(adapter, "adapter_id", adapter.__class__.__qualname__)
+        return cls(connector_id=connector_id, bucking_id=bucking_id, adapter_ids=adapter_ids)
+
+
+@dataclass(frozen=True)
+class PartKey:
+    """Encoded representation of a single model view."""
+
+    part: str
+    view_type: str
+    payload_hex: str
+
+
+@dataclass(frozen=True)
+class ModelViewStateKey:
+    """Cache-ready encoding of model views grouped by stand part."""
+
+    namespace: str
+    parts: Tuple[PartKey, ...]
+
+    def as_cache_key(self) -> Tuple[str, Tuple[Tuple[str, str, str], ...]]:
+        """Return a tuple suitable for use as a cache dictionary key."""
+
+        return (
+            self.namespace,
+            tuple((part.part, part.view_type, part.payload_hex) for part in self.parts),
+        )
+
+
+def _pickle_view(model_view: Any) -> str:
+    try:
+        payload = pickle.dumps(model_view, protocol=pickle.HIGHEST_PROTOCOL)
+    except pickle.PicklingError as exc:  # pragma: no cover - defensive guard
+        raise TypeError("Model view must be serialisable with pickle.") from exc
+    return payload.hex()
+
+
+def _unpickle_view(payload_hex: str) -> Any:
+    payload = bytes.fromhex(payload_hex)
+    return pickle.loads(payload)
+
+
+def encode_model_views(
+    model_views: Mapping[str, Any],
+    provenance: SimulationProvenance,
+) -> ModelViewStateKey:
+    """Encode ``model_views`` into a :class:`ModelViewStateKey`."""
+
+    encoded_parts = []
+    for part, view in sorted(model_views.items(), key=lambda item: item[0]):
+        view_type = f"{view.__class__.__module__}:{view.__class__.__qualname__}"
+        encoded_parts.append(
+            PartKey(
+                part=str(part),
+                view_type=view_type,
+                payload_hex=_pickle_view(view),
+            )
+        )
+    return ModelViewStateKey(namespace=provenance.namespace, parts=tuple(encoded_parts))
+
+
+def decode_model_views(state_key: ModelViewStateKey) -> Dict[str, Any]:
+    """Return the decoded model views for ``state_key``."""
+
+    decoded: Dict[str, Any] = {}
+    for part in state_key.parts:
+        decoded[part.part] = _unpickle_view(part.payload_hex)
+    return decoded
+
+
+def simulate_one_step_pure(
+    state_key: ModelViewStateKey,
+    *,
+    action: str,
+    adapters: Mapping[str, DeterministicAdapter],
+    provenance: SimulationProvenance,
+) -> Tuple[ModelViewStateKey, float]:
+    """Advance ``state_key`` by one action using deterministic ``adapters``."""
+
+    if state_key.namespace != provenance.namespace:
+        raise ValueError(
+            "State key namespace does not match the supplied provenance; the cache "
+            "entry was produced by incompatible connectors or adapters."
+        )
+    current_views = decode_model_views(state_key)
+    next_views: MutableMapping[str, Any] = {}
+    total_reward = 0.0
+    for part_name, current_view in current_views.items():
+        try:
+            adapter = adapters[part_name]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"Missing deterministic adapter for part '{part_name}'.") from exc
+        next_view, reward = adapter.apply(part=part_name, action=action, model_view=current_view)
+        next_views[part_name] = next_view
+        total_reward += float(reward)
+    next_key = encode_model_views(next_views, provenance)
+    return next_key, total_reward
+
+
+__all__ = [
+    "DeterministicAdapter",
+    "ModelViewStateKey",
+    "PartKey",
+    "SimulationProvenance",
+    "decode_model_views",
+    "encode_model_views",
+    "simulate_one_step_pure",
+]

--- a/tests/simulation/dp/test_state_key.py
+++ b/tests/simulation/dp/test_state_key.py
@@ -1,0 +1,152 @@
+"""Tests for the dynamic-programming state key utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from pyforestry.simulation.dp import (
+    SimulationProvenance,
+    decode_model_views,
+    encode_model_views,
+    simulate_one_step_pure,
+)
+
+
+@dataclass(eq=True)
+class DummyView:
+    """Simple view used for property-based testing."""
+
+    value: int
+    label: str
+
+
+class SimpleAdapter:
+    """Deterministic adapter whose transitions depend only on the inputs."""
+
+    def __init__(self, adapter_id: str, base_shift: int) -> None:
+        self.adapter_id = adapter_id
+        self._base_shift = base_shift
+
+    def delta(self, *, part: str, action: str, view: DummyView) -> int:
+        """Return the deterministic increment applied to ``view``."""
+
+        return self._base_shift + len(part) + len(action) + len(view.label)
+
+    def apply(self, *, part: str, action: str, model_view: DummyView):
+        shift = self.delta(part=part, action=action, view=model_view)
+        new_label = f"{model_view.label}:{action}" if model_view.label else action
+        updated_view = DummyView(value=model_view.value + shift, label=new_label)
+        return updated_view, float(updated_view.value)
+
+
+lower_alpha = st.characters(min_codepoint=97, max_codepoint=122)
+part_names = st.text(min_size=1, max_size=5, alphabet=lower_alpha)
+labels = st.text(min_size=0, max_size=5, alphabet=lower_alpha)
+views = st.builds(DummyView, value=st.integers(-50, 50), label=labels)
+
+
+@given(
+    parts=st.dictionaries(part_names, views, min_size=1, max_size=4),
+)
+def test_encode_decode_round_trip(parts: Dict[str, DummyView]) -> None:
+    """Encoding a view mapping should be reversible and namespace aware."""
+
+    provenance = SimulationProvenance(
+        connector_id="connector-test",
+        bucking_id="bucker-test",
+        adapter_ids={name: f"adapter-{index}" for index, name in enumerate(parts, start=1)},
+    )
+    state_key = encode_model_views(parts, provenance)
+    decoded = decode_model_views(state_key)
+
+    assert decoded == parts
+    assert state_key.namespace == provenance.namespace
+    cache_namespace, _ = state_key.as_cache_key()
+    assert cache_namespace == state_key.namespace
+    assert provenance.connector_id in state_key.namespace
+    assert provenance.bucking_id in state_key.namespace
+    for adapter_id in provenance.adapter_ids.values():
+        assert adapter_id in state_key.namespace
+
+
+@given(
+    parts=st.dictionaries(part_names, views, min_size=1, max_size=4),
+    action=st.text(min_size=1, max_size=4, alphabet=lower_alpha),
+    connector=st.text(min_size=1, max_size=4, alphabet=lower_alpha),
+    bucking=st.text(min_size=1, max_size=4, alphabet=lower_alpha),
+)
+def test_simulate_one_step_pure_is_deterministic(
+    parts: Dict[str, DummyView],
+    action: str,
+    connector: str,
+    bucking: str,
+) -> None:
+    """Transitions derived from identical inputs should match exactly."""
+
+    adapters = {
+        part: SimpleAdapter(adapter_id=f"adapter-{index}", base_shift=index)
+        for index, part in enumerate(sorted(parts), start=1)
+    }
+    provenance = SimulationProvenance.from_adapters(
+        connector_id=connector,
+        bucking_id=bucking,
+        adapters=adapters,
+    )
+    state_key = encode_model_views(parts, provenance)
+
+    next_key, reward = simulate_one_step_pure(
+        state_key,
+        action=action,
+        adapters=adapters,
+        provenance=provenance,
+    )
+    second_key, second_reward = simulate_one_step_pure(
+        state_key,
+        action=action,
+        adapters=adapters,
+        provenance=provenance,
+    )
+
+    assert next_key == second_key
+    assert reward == second_reward
+
+    decoded_next = decode_model_views(next_key)
+    expected_reward = 0.0
+    for part, updated in decoded_next.items():
+        original = parts[part]
+        shift = adapters[part].delta(part=part, action=action, view=original)
+        assert updated.value == original.value + shift
+        assert updated.label.endswith(action)
+        expected_reward += float(updated.value)
+    assert reward == expected_reward
+
+
+def test_namespace_mismatch_rejected() -> None:
+    """simulate_one_step_pure refuses to combine incompatible provenance."""
+
+    parts = {"north": DummyView(value=5, label="seed")}
+    adapters = {"north": SimpleAdapter(adapter_id="adapter-1", base_shift=1)}
+    provenance = SimulationProvenance.from_adapters(
+        connector_id="conn-a",
+        bucking_id="buck-a",
+        adapters=adapters,
+    )
+    state_key = encode_model_views(parts, provenance)
+    mismatched = SimulationProvenance(
+        connector_id="conn-b",
+        bucking_id="buck-a",
+        adapter_ids={"north": "adapter-1"},
+    )
+
+    with pytest.raises(ValueError):
+        simulate_one_step_pure(
+            state_key,
+            action="grow",
+            adapters=adapters,
+            provenance=mismatched,
+        )


### PR DESCRIPTION
## Summary
- add dynamic-programming state key utilities that encode model views, manage provenance, and drive deterministic one-step simulations
- expose the DP helpers via the simulation package and add Hypothesis to the development dependencies
- add property-based tests covering encode/decode round-trips and deterministic adapter behaviour

## Testing
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50

------
https://chatgpt.com/codex/tasks/task_e_68ea6c08157483298ddcfc5a829c15da