### PR TITLE
Add stage contract enforcement for RNG and I/O

### DIFF
--- a/src/pyforestry/simulation/__init__.py
+++ b/src/pyforestry/simulation/__init__.py
@@ -1,5 +1,6 @@
 """Simulation-facing views and orchestration helpers."""
 
+from .contracts import StageContract
 from .dp import (
     DeterministicAdapter,
     ModelViewStateKey,
@@ -54,6 +55,7 @@ __all__ = [
     "ValuationStage",
     "Stage",
     "StageAction",
+    "StageContract",
     "StandRemovalLedger",
     "CohortRemoval",
     "TreeRemoval",

--- a/src/pyforestry/simulation/contracts.py
+++ b/src/pyforestry/simulation/contracts.py
@@ -1,0 +1,22 @@
+"""Contracts describing the capabilities exposed by simulation stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, FrozenSet, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class StageContract:
+    """Describe the interfaces and side effects offered by a stage."""
+
+    type_metadata: Mapping[str, Any] = field(default_factory=dict)
+    units: Mapping[str, str] = field(default_factory=dict)
+    crs: Optional[str] = None
+    effects: FrozenSet[str] = field(default_factory=lambda: frozenset({"rng"}))
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "type_metadata", MappingProxyType(dict(self.type_metadata)))
+        object.__setattr__(self, "units", MappingProxyType(dict(self.units)))
+        object.__setattr__(self, "effects", frozenset(self.effects))


### PR DESCRIPTION
## Summary
- add a `StageContract` dataclass to describe stage metadata and declared effects
- plumb stage contracts through the growth module so keyed RNG access honours effect declarations
- enforce RNG and I/O requests in `StandPart.apply_action` and cover the behaviour with new regression tests

## Testing
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50

------
https://chatgpt.com/codex/tasks/task_e_68ea911300e483298fe5b1aa720bbfa6