### PR TITLE
Ensure angle-count stand metrics expose totals

### DIFF
--- a/src/pyforestry/base/helpers/stand.py
+++ b/src/pyforestry/base/helpers/stand.py
@@ -203,8 +203,12 @@ class Stand:
             stems_metrics: Dict[Any, Union[Stems, StandBasalArea]] = {
                 k: v for k, v in stems_from_angle_count.items()
             }
-            self._metric_estimates["BasalArea"] = basal_area_metrics
-            self._metric_estimates["Stems"] = stems_metrics
+            self._metric_estimates["BasalArea"] = self._with_total_entry(
+                basal_area_metrics, StandBasalArea
+            )
+            self._metric_estimates["Stems"] = self._with_total_entry(
+                stems_metrics, Stems
+            )
             self.use_angle_count = True
         else:
             self.use_angle_count = False
@@ -250,6 +254,38 @@ class Stand:
     def BAWAD(self) -> StandMetricAccessor:
         """Access the stand's basal-area weighted mean diameter."""
         return StandMetricAccessor(self, "BAWAD")
+
+    @staticmethod
+    def _with_total_entry(
+        metric_dict: Dict[Any, Union[Stems, StandBasalArea]],
+        metric_type: type,
+    ) -> Dict[Any, Union[Stems, StandBasalArea]]:
+        """Return a copy of ``metric_dict`` with an added ``"TOTAL"`` entry."""
+
+        metrics = list(metric_dict.values())
+
+        total_value = sum(metric.value for metric in metrics) if metrics else 0.0
+        total_precision = (
+            sqrt(sum(metric.precision**2 for metric in metrics)) if metrics else 0.0
+        )
+
+        kwargs: Dict[str, Any] = {}
+        if metrics:
+            sample = metrics[0]
+            for attr in ("over_bark", "direct_estimate"):
+                if hasattr(sample, attr):
+                    kwargs[attr] = all(getattr(metric, attr) for metric in metrics)
+
+        metric_with_total: Dict[Any, Union[Stems, StandBasalArea]] = {
+            k: v for k, v in metric_dict.items()
+        }
+        metric_with_total["TOTAL"] = metric_type(
+            total_value,
+            species=None,
+            precision=total_precision,
+            **kwargs,
+        )
+        return metric_with_total
 
     def _ensure_qmd_estimates(self):
         """

--- a/tests/base/test_stand_plot.py
+++ b/tests/base/test_stand_plot.py
@@ -134,6 +134,31 @@ def test_bawad_unavailable_with_angle_count():
         float(st.BAWAD)
 
 
+def test_angle_count_totals_available():
+    """Angle-count derived stands should expose TOTAL entries for metrics."""
+    sp1 = parse_tree_species("picea abies")
+    sp2 = parse_tree_species("pinus sylvestris")
+    ac = AngleCount(ba_factor=2.0, value=[4, 2], species=[sp1, sp2], point_id="P1")
+    plot = CircularPlot(id=1, radius_m=5, AngleCount=[ac])
+    stand = Stand(plots=[plot])
+
+    ba_species = [stand.BasalArea(sp1), stand.BasalArea(sp2)]
+    stems_species = [stand.Stems(sp1), stand.Stems(sp2)]
+
+    total_ba = stand.BasalArea.TOTAL
+    total_stems = stand.Stems.TOTAL
+
+    assert math.isclose(total_ba.value, sum(metric.value for metric in ba_species))
+    assert math.isclose(
+        total_ba.precision, math.sqrt(sum(metric.precision**2 for metric in ba_species))
+    )
+    assert math.isclose(total_stems.value, sum(metric.value for metric in stems_species))
+    assert math.isclose(
+        total_stems.precision,
+        math.sqrt(sum(metric.precision**2 for metric in stems_species)),
+    )
+
+
 def test_CircularPlot_area_ha_property():
     """Simple test of the CircularPlot area_ha property."""
     p = CircularPlot(id=10, radius_m=10)


### PR DESCRIPTION
## Summary
- ensure stands backed by angle-count data populate TOTAL entries for basal area and stem metrics
- add regression coverage asserting TOTAL access for angle-count-derived stands

## Testing
- pytest --cov=pyforestry --cov-report=xml --cov-report=html --cov-fail-under=50
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68f63516520c83299678dcc7cd01b6c3