### PR TITLE
Fix/reuse timber in swetimber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 .coverage
 pandoc-*.deb
 docs/source/pandoc-*.deb
+.idea/

--- a/src/pyforestry/base/timber/timber_base/timber.py
+++ b/src/pyforestry/base/timber/timber_base/timber.py
@@ -16,6 +16,7 @@ class Timber:
         over_bark: Optional[bool] = None,
         stump_height_m: Optional[float] = 0.3,
     ):
+        """Instantiate a timber record and infer missing fields."""
         self.species = species.lower()
         self.diameter_cm = diameter_cm
         self.height_m = height_m
@@ -27,6 +28,7 @@ class Timber:
         self._validate_timber()
 
     def validate(self):
+        """Validate that the provided tree attributes are sensible."""
         self._validate_timber()
 
     def _validate_timber(self) -> None:

--- a/src/pyforestry/base/timber/timber_base/timber.py
+++ b/src/pyforestry/base/timber/timber_base/timber.py
@@ -30,10 +30,10 @@ class Timber:
         """Validate that the provided tree attributes are sensible."""
 
         if self.height_m <= 0:
-            raise ValueError("Height must be larger than 0 m: {self.height_m}")
+            raise ValueError(f"Height must be larger than 0 m: {self.height_m}")
 
         if self.diameter_cm < 0:
-            raise ValueError("Diameter must be larger or equal to than 0 cm: {self.diameter_cm}")
+            raise ValueError(f"Diameter must be larger or equal to than 0 cm: {self.diameter_cm}")
 
         if (
             self.crown_base_height_m is not None

--- a/src/pyforestry/base/timber/timber_base/timber.py
+++ b/src/pyforestry/base/timber/timber_base/timber.py
@@ -24,9 +24,12 @@ class Timber:
         self.over_bark = over_bark
         self.stump_height_m = stump_height_m
 
-        self.validate()
+        self._validate_timber()
 
-    def validate(self) -> None:
+    def validate(self):
+        self._validate_timber()
+
+    def _validate_timber(self) -> None:
         """Validate that the provided tree attributes are sensible."""
 
         if self.height_m <= 0:

--- a/src/pyforestry/sweden/timber/swe_timber.py
+++ b/src/pyforestry/sweden/timber/swe_timber.py
@@ -37,12 +37,16 @@ class SweTimber(Timber):
         swedish_site: Optional[SwedishSite] = None,
     ):
         """Instantiate a timber record and infer missing fields."""
-        self.species = species.lower()
-        self.diameter_cm = diameter_cm
-        self.height_m = height_m
-        self.double_bark_mm = double_bark_mm
-        self.crown_base_height_m = crown_base_height_m
-        self.over_bark = over_bark
+        super().__init__(
+            species=species,
+            diameter_cm=diameter_cm,
+            height_m=height_m,
+            double_bark_mm=double_bark_mm,
+            crown_base_height_m=crown_base_height_m,
+            over_bark=over_bark,
+            stump_height_m=0.01 * height_m  # Calculated stump height
+        )
+
         self.region = region.lower()
         self.swedish_site = swedish_site
 
@@ -57,31 +61,16 @@ class SweTimber(Timber):
         else:
             self.latitude = latitude
 
-        # Calculate stump height.
-        self.stump_height_m = 0.01 * height_m
-
-        self.validate()
+        # Validate the special cases for SweTimber. The rest is validated in parent class.
+        self._validate_swe_timber()
 
     def validate(self):
-        """Verify that provided parameters are within valid ranges."""
-        if self.height_m <= 0:
-            raise ValueError("Height must be larger than 0 m: {self.height_m}")
+        super().validate()
+        self._validate_swe_timber()
 
-        if self.diameter_cm < 0:
-            raise ValueError(f"Diameter must be larger or equal to 0 cm: {self.diameter_cm}")
-        if (
-            self.crown_base_height_m is not None
-            and self.height_m is not None
-            and self.crown_base_height_m >= self.height_m
-        ):
-            raise ValueError(
-                f"Crown base height ({self.crown_base_height_m} m) cannot be higher than "
-                f"tree height: {self.height_m} m"
-            )
-        if self.stump_height_m < 0:
-            raise ValueError(
-                f"Stump height must be larger or equal to 0 m: {self.stump_height_m}"
-            )  # pragma: no cover - unreachable
+    def _validate_swe_timber(self):
+        """Validate the special cases for SweTimber"""
+
         if self.region not in ["northern", "southern"]:
             raise ValueError("Region must be 'northern' or 'southern'.")
         if self.species not in [

--- a/src/pyforestry/sweden/timber/swe_timber.py
+++ b/src/pyforestry/sweden/timber/swe_timber.py
@@ -44,7 +44,7 @@ class SweTimber(Timber):
             double_bark_mm=double_bark_mm,
             crown_base_height_m=crown_base_height_m,
             over_bark=over_bark,
-            stump_height_m=0.01 * height_m  # Calculated stump height
+            stump_height_m=0.01 * height_m,  # Calculated stump height
         )
 
         self.region = region.lower()
@@ -65,6 +65,7 @@ class SweTimber(Timber):
         self._validate_swe_timber()
 
     def validate(self):
+        """Validate that the provided tree attributes are sensible."""
         super().validate()
         self._validate_swe_timber()
 

--- a/tests/base/test_base_timber_validation.py
+++ b/tests/base/test_base_timber_validation.py
@@ -31,8 +31,10 @@ def test_validate_crown_base_below_height():
 
 
 def test_validate_stump_height_non_negative():
-    stump_height_m=-0.1
-    with pytest.raises(ValueError, match=f"Stump height must be larger or equal to 0 m: {stump_height_m}"):
+    stump_height_m = -0.1
+    with pytest.raises(
+        ValueError, match=f"Stump height must be larger or equal to 0 m: {stump_height_m}"
+    ):
         Timber(species="pine", diameter_cm=10, height_m=10, stump_height_m=stump_height_m)
 
 

--- a/tests/base/test_base_timber_validation.py
+++ b/tests/base/test_base_timber_validation.py
@@ -14,8 +14,9 @@ class DummyTaper:
 
 
 def test_validate_height_positive():
-    with pytest.raises(ValueError, match="Height must be larger than 0 m: {self.height_m}"):
-        Timber(species="pine", diameter_cm=10, height_m=0)
+    height_m = 0
+    with pytest.raises(ValueError, match=f"Height must be larger than 0 m: {height_m}"):
+        Timber(species="pine", diameter_cm=10, height_m=height_m)
 
 
 def test_validate_crown_base_below_height():
@@ -30,8 +31,9 @@ def test_validate_crown_base_below_height():
 
 
 def test_validate_stump_height_non_negative():
-    with pytest.raises(ValueError, match="Stump height must be larger or equal to 0 m: -0.1"):
-        Timber(species="pine", diameter_cm=10, height_m=10, stump_height_m=-0.1)
+    stump_height_m=-0.1
+    with pytest.raises(ValueError, match=f"Stump height must be larger or equal to 0 m: {stump_height_m}"):
+        Timber(species="pine", diameter_cm=10, height_m=10, stump_height_m=stump_height_m)
 
 
 def test_cylinder_volume_integrand_none():

--- a/tests/sweden/test_taper.py
+++ b/tests/sweden/test_taper.py
@@ -121,11 +121,12 @@ def test_invalid_timber_raises_error():
     Tests that the constructor raises a ValueError when provided with
     an invalid timber object (e.g., height <= 0).
     """
-    with pytest.raises(ValueError, match="Height must be larger than 0 m: {self.height_m}"):
+    height_m = 0
+    with pytest.raises(ValueError, match=f"Height must be larger than 0 m: {height_m}"):
         invalid_timber = SweTimber(
             species="picea abies",
             diameter_cm=30,
-            height_m=0,
+            height_m=height_m,
             region="northern",  # Invalid height
         )
         EdgrenNylinder1949(invalid_timber)


### PR DESCRIPTION
I found a minor bug in the Timber class. That led to that I looked into the Timber and SweTimber classes. In my opinion the __init__()-function in SweTimber can reuse much of the code in Timber. That way the __init__ logic gets centralized in the Timber class and the code does not need to be maintained at two places that do the same thing.
The validation function gets defined in separate sub-functions so the shared parts can be reused. 